### PR TITLE
two small cleanups

### DIFF
--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -10,7 +10,9 @@ defmodule Jason do
 
   @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> term)
 
-  @type decode_opt :: {:keys, keys}
+  @type strings :: :reference | :copy
+
+  @type decode_opt :: {:keys, keys} | {:strings, strings}
 
   alias Jason.{Encode, Decoder, DecodeError, EncodeError}
 

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -56,7 +56,7 @@ defmodule Jason do
   """
   @spec decode!(iodata, [decode_opt]) :: term | no_return
   def decode!(input, opts \\ []) do
-    case Decoder.parse(input, format_decode_opts(opts)) do
+    case decode(input, opts) do
       {:ok, result} -> result
       {:error, error} -> raise error
     end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -132,6 +132,12 @@ defmodule Jason.DecodeTest do
     assert parse!(~s(  {  "foo"  :  "bar"  ,  "baz"  :  "quux"  }  )) == expected
   end
 
+  test "iodata" do
+    body = String.split(~s([1,2,3,4]), "")
+    expected = [1, 2, 3, 4]
+    assert parse!(body) == expected
+  end
+
   defp parse!(json, opts \\ []) do
     Jason.decode!(json, opts)
   end


### PR DESCRIPTION
* add a type for the `:strings` option to `decode/2`
* support iodata as an argument to `decode!/2`