### PR TITLE
Tuples support

### DIFF
--- a/dialyzer.ignore
+++ b/dialyzer.ignore
@@ -2,4 +2,3 @@ Unknown function 'Elixir.Jason.Encoder.Function':'__impl__'/1
 Unknown function 'Elixir.Jason.Encoder.PID':'__impl__'/1
 Unknown function 'Elixir.Jason.Encoder.Port':'__impl__'/1
 Unknown function 'Elixir.Jason.Encoder.Reference':'__impl__'/1
-Unknown function 'Elixir.Jason.Encoder.Tuple':'__impl__'/1

--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -43,8 +43,9 @@ defmodule Jason.Decoder do
   def parse(data, opts) when is_binary(data) do
     key_decode = key_decode_function(opts)
     string_decode = string_decode_function(opts)
+    tuple_decode = tuple_decode_function(opts)
     try do
-      value(data, data, 0, [@terminate], key_decode, string_decode)
+      value(data, data, 0, [@terminate], key_decode, string_decode, tuple_decode)
     catch
       {:position, position} ->
         {:error, %DecodeError{position: position, data: data}}
@@ -64,156 +65,164 @@ defmodule Jason.Decoder do
   defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
   defp string_decode_function(%{strings: :reference}), do: &(&1)
 
-  defp value(data, original, skip, stack, key_decode, string_decode) do
+  defp tuple_decode_function(%{tuples: :tuple}), do: &list_to_tuple/1
+  defp tuple_decode_function(%{tuples: :none}), do: &(&1)
+  
+  def list_to_tuple(["__tuple__" | tuple]), do: List.to_tuple(tuple)
+  def list_to_tuple(list), do: list
+
+  defp value(data, original, skip, stack, key_decode, string_decode, tuple_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        value(rest, original, skip + 1, stack, key_decode, string_decode)
+        value(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       _ in '0', rest ->
-        number_zero(rest, original, skip, stack, key_decode, string_decode, 1)
+        number_zero(rest, original, skip, stack, key_decode, string_decode, tuple_decode, 1)
       _ in '123456789', rest ->
-        number(rest, original, skip, stack, key_decode, string_decode, 1)
+        number(rest, original, skip, stack, key_decode, string_decode, tuple_decode, 1)
       _ in '-', rest ->
-        number_minus(rest, original, skip, stack, key_decode, string_decode)
+        number_minus(rest, original, skip, stack, key_decode, string_decode, tuple_decode)
       _ in '"', rest ->
-        string(rest, original, skip + 1, stack, key_decode, string_decode, 0)
+        string(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, 0)
       _ in '[', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       _ in '{', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       _ in ']', rest ->
-        empty_array(rest, original, skip + 1, stack, key_decode, string_decode)
+        empty_array(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       _ in 't', rest ->
         case rest do
           <<"rue", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, true)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, tuple_decode, true)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'f', rest ->
         case rest do
           <<"alse", rest::bits>> ->
-            continue(rest, original, skip + 5, stack, key_decode, string_decode, false)
+            continue(rest, original, skip + 5, stack, key_decode, string_decode, tuple_decode, false)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'n', rest ->
         case rest do
           <<"ull", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, nil)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, tuple_decode, nil)
           <<_::bits>> ->
             error(original, skip)
         end
       _, rest ->
-        error(rest, original, skip + 1, stack, key_decode, string_decode)
+        error(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       <<_::bits>> ->
         error(original, skip)
     end
   end
 
-  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    number_zero(rest, original, skip, stack, key_decode, string_decode, 2)
+  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode) do
+    number_zero(rest, original, skip, stack, key_decode, string_decode, tuple_decode, 2)
   end
-  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode)
+  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode)
        when byte in '123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, 2)
+    number(rest, original, skip, stack, key_decode, string_decode, tuple_decode, 2)
   end
-  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode) do
+  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode) do
     error(original, skip + 1)
   end
 
-  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len)
        when byte in '0123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
+  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) 
+      when e in 'eE' do
     prefix = binary_part(original, skip, len)
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, prefix)
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, tuple_decode, prefix)
   end
-  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
     int = String.to_integer(binary_part(original, skip, len))
-    continue(rest, original, skip + len, stack, key_decode, string_decode, int)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, int)
   end
 
-  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode,  len) 
        when e in 'eE' do
-    number_exp(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
     token = binary_part(original, skip, len)
     float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, float)
   end
 
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode,  len) 
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) 
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
     token = binary_part(original, skip, len)
     float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, float)
   end
 
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, prefix) 
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, 1)
   end
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, prefix) 
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, 1)
   end
-  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix) do
+  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, _prefix) do
     error(original, skip)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, prefix,
+       len) when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, _prefix,
+       len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, 
+       len) when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, prefix, len) do
     suffix = binary_part(original, skip, len)
     string = prefix <> ".0e" <> suffix
     prefix_size = byte_size(prefix)
@@ -221,45 +230,46 @@ defmodule Jason.Decoder do
     final_skip = skip + len
     token = binary_part(original, initial_skip, prefix_size + len + 1)
     float = try_parse_float(string, token, initial_skip)
-    continue(rest, original, final_skip, stack, key_decode, string_decode, float)
+    continue(rest, original, final_skip, stack, key_decode, string_decode, tuple_decode, float)
   end
 
-  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
   end
-  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, "0")
+  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) 
+       when e in 'eE' do
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, tuple_decode, "0")
   end
-  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    continue(rest, original, skip + len, stack, key_decode, string_decode, 0)
-  end
-
-  @compile {:inline, array: 6}
-
-  defp array(rest, original, skip, stack, key_decode, string_decode) do
-    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode)
+  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
+    continue(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, 0)
   end
 
-  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode) do
+  @compile {:inline, array: 7}
+
+  defp array(rest, original, skip, stack, key_decode, string_decode, tuple_decode) do
+    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode, tuple_decode)
+  end
+
+  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode) do
     case stack do
       [@array, [] | stack] ->
-        continue(rest, original, skip, stack, key_decode, string_decode, [])
+        continue(rest, original, skip, stack, key_decode, string_decode, tuple_decode, [])
       _ ->
         error(original, skip - 1)
     end
   end
 
-  defp array(data, original, skip, stack, key_decode, string_decode, value) do
+  defp array(data, original, skip, stack, key_decode, string_decode, tuple_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, value)
       _ in ']', rest ->
         [acc | stack] = stack
-        value = :lists.reverse(acc, [value])
-        continue(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        value = acc |> :lists.reverse([value]) |> tuple_decode.()
+        continue(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, value)
       _ in ',', rest ->
         [acc | stack] = stack
-        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode, tuple_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -267,26 +277,26 @@ defmodule Jason.Decoder do
     end
   end
 
-  @compile {:inline, object: 6}
+  @compile {:inline, object: 7}
 
-  defp object(rest, original, skip, stack, key_decode, string_decode) do
-    key(rest, original, skip, [[] | stack], key_decode, string_decode)
+  defp object(rest, original, skip, stack, key_decode, string_decode, tuple_decode) do
+    key(rest, original, skip, [[] | stack], key_decode, string_decode, tuple_decode)
   end
 
-  defp object(data, original, skip, stack, key_decode, string_decode, value) do
+  defp object(data, original, skip, stack, key_decode, string_decode, tuple_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, value)
       _ in '}', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         final = [{key_decode.(key), value} | acc]
-        continue(rest, original, skip, stack, key_decode, string_decode, :maps.from_list(final))
+        continue(rest, original, skip, stack, key_decode, string_decode, tuple_decode, :maps.from_list(final))
       _ in ',', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         acc = [{key_decode.(key), value} | acc]
-        key(rest, original, skip, [acc | stack], key_decode, string_decode)
+        key(rest, original, skip, [acc | stack], key_decode, string_decode, tuple_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -294,19 +304,19 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode) do
+  defp key(data, original, skip, stack, key_decode, string_decode, tuple_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode)
       _ in '}', rest ->
         case stack do
           [[] | stack] ->
-            continue(rest, original, skip + 1, stack, key_decode, string_decode, %{})
+            continue(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, %{})
           _ ->
             error(original, skip)
         end
       _ in '"', rest ->
-        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, 0)
+        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, tuple_decode, 0)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -314,12 +324,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, key_decode, string_decode, tuple_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, value)
       _ in ':', rest ->
-        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode, tuple_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -330,73 +340,73 @@ defmodule Jason.Decoder do
   # TODO: check if this approach would be faster:
   # https://git.ninenines.eu/cowlib.git/tree/src/cow_ws.erl#n469
   # http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
-  defp string(data, original, skip, stack, key_decode, string_decode, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, tuple_decode, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         string = string_decode.(binary_part(original, skip, len))
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, tuple_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, part)
+        escape(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, part)
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp string(data, original, skip, stack, key_decode, string_decode, acc, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, tuple_decode, acc, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         last = binary_part(original, skip, len)
         string = IO.iodata_to_binary([acc | last])
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, tuple_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, [acc | part])
+        escape(rest, original, skip + len, stack, key_decode, string_decode, tuple_decode, [acc | part])
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp escape(data, original, skip, stack, key_decode, string_decode, acc) do
+  defp escape(data, original, skip, stack, key_decode, string_decode, tuple_decode, acc) do
     bytecase data do
       _ in 'b', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\b'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\b'], 0)
       _ in 't', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\t'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\t'], 0)
       _ in 'n', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\n'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\n'], 0)
       _ in 'f', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\f'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\f'], 0)
       _ in 'r', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\r'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\r'], 0)
       _ in '"', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\"'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\"'], 0)
       _ in '/', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '/'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '/'], 0)
       _ in '\\', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\\'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, tuple_decode, [acc | '\\'], 0)
       _ in 'u', rest ->
-        escapeu(rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu(rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc)
       _, _rest ->
         error(original, skip + 1)
       <<_::bits>> ->
@@ -432,8 +442,8 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, acc) do
-      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode,  tuple_decode,acc)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -441,20 +451,21 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc) do
+    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc) do
       for {int, first} <- unicode_escapes(),
           not (first in 0xDC..0xDF) do
-        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode,
+          tuple_decode,acc)
       end
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
-         when first in 0xD8..0xDB do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode,
+         acc) when first in 0xD8..0xDB do
       hi =
         quote bind_quoted: [first: first, last: last] do
           0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, hi]
+      args = [rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, hi]
       [clause] =
         quote location: :keep do
           unquote(int) -> escape_surrogate(unquote_splicing(args))
@@ -462,8 +473,8 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
-         when first <= 0x00 do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode,
+         acc) when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last] do
@@ -477,7 +488,7 @@ defmodule Jason.Decoder do
             [acc, byte1, byte2]
           end
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -485,8 +496,8 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
-         when first <= 0x07 do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode,
+         tuple_decode,acc) when first <= 0x07 do
       skip = quote do: (unquote(skip) + 6)
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last] do
@@ -495,7 +506,7 @@ defmodule Jason.Decoder do
           byte2 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -503,8 +514,8 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
-         when first <= 0xFF do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode,
+         acc) when first <= 0xFF do
       skip = quote do: (unquote(skip) + 6)
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last] do
@@ -514,7 +525,7 @@ defmodule Jason.Decoder do
           byte3 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2, byte3]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -541,9 +552,10 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, 
+        tuple_decode,acc, hi)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -551,22 +563,25 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc,
+         hi) do
       digits1 = 'Dd'
       digits2 = Stream.concat([?C..?F, ?c..?f])
       for {int, first} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, 
+          tuple_decode,acc, hi)
       end
     end
 
-    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode,
+         tuple_decode, acc, hi) do
       skip = quote do: unquote(skip) + 12
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
           lo = ((first &&& 0x03) <<< 8) + last
           [acc | <<(hi + lo)::utf8>>]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
@@ -576,12 +591,13 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode,
+       acc) do
     require Unescape
     last = escapeu_last(int2, original, skip)
-    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode, acc)
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc) do
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, _acc) do
     empty_error(original, skip)
   end
 
@@ -593,12 +609,14 @@ defmodule Jason.Decoder do
   end
 
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
-       skip, stack, key_decode, string_decode, acc, hi) do
+       skip, stack, key_decode, string_decode, tuple_decode, acc, hi) do
     require Unescape
     last = escapeu_last(int2, original, skip + 6)
-    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, tuple_decode,acc,
+      hi)
   end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc, _hi) do
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, _acc,
+       _hi) do
     error(original, skip + 6)
   end
 
@@ -609,7 +627,7 @@ defmodule Jason.Decoder do
       token_error(token, skip)
   end
 
-  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode) do
+  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode, _tuple_decode) do
     throw {:position, skip - 1}
   end
 
@@ -630,28 +648,28 @@ defmodule Jason.Decoder do
     throw {:token, binary_part(token, position, len), position}
   end
 
-  @compile {:inline, continue: 7}
-  defp continue(rest, original, skip, stack, key_decode, string_decode, value) do
+  @compile {:inline, continue: 8}
+  defp continue(rest, original, skip, stack, key_decode, string_decode, tuple_decode, value) do
     case stack do
       [@terminate | stack] ->
-        terminate(rest, original, skip, stack, key_decode, string_decode, value)
+        terminate(rest, original, skip, stack, key_decode, string_decode, tuple_decode, value)
       [@array | stack] ->
-        array(rest, original, skip, stack, key_decode, string_decode, value)
+        array(rest, original, skip, stack, key_decode, string_decode, tuple_decode, value)
       [@key | stack] ->
-        key(rest, original, skip, stack, key_decode, string_decode, value)
+        key(rest, original, skip, stack, key_decode, string_decode, tuple_decode, value)
       [@object | stack] ->
-        object(rest, original, skip, stack, key_decode, string_decode, value)
+        object(rest, original, skip, stack, key_decode, string_decode, tuple_decode, value)
     end
   end
 
-  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, value)
+  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, tuple_decode, value)
        when byte in '\s\n\r\t' do
-    terminate(rest, original, skip + 1, stack, key_decode, string_decode, value)
+    terminate(rest, original, skip + 1, stack, key_decode, string_decode, tuple_decode, value)
   end
-  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, value) do
+  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, _tuple_decode, value) do
     value
   end
-  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _value) do
+  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _tuple_decode, _value) do
     error(original, skip)
   end
 end

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -80,14 +80,15 @@ defimpl Jason.Encoder, for: Any do
     kv = Enum.map(fields, &{&1, generated_var(&1, __MODULE__)})
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
+    encode_tuple = quote(do: encode_tuple)
+    encode_args = [escape, encode_map, encode_tuple]
     kv_iodata = Jason.Codegen.build_kv_iodata(kv, encode_args)
 
     quote do
       defimpl Jason.Encoder, for: unquote(module) do
         require Jason.Helpers
 
-        def encode(%{unquote_splicing(kv)}, {unquote(escape), unquote(encode_map)}) do
+        def encode(%{unquote_splicing(kv)}, {unquote(escape), unquote(encode_map), unquote(encode_tuple)}) do
           unquote(kv_iodata)
         end
       end
@@ -173,6 +174,12 @@ end
 defimpl Jason.Encoder, for: List do
   def encode(list, opts) do
     Jason.Encode.list(list, opts)
+  end
+end
+
+defimpl Jason.Encoder, for: Tuple do
+  def encode(tuple, opts) do
+    Jason.Encode.tuple(tuple, opts)
   end
 end
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -32,12 +32,13 @@ defmodule Jason.Helpers do
   defmacro json_map(kv) do
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
+    encode_tuple = quote(do: encode_tuple)
+    encode_args = [escape, encode_map, encode_tuple]
     kv_iodata = Codegen.build_kv_iodata(Macro.expand(kv, __CALLER__), encode_args)
 
     quote do
       %Fragment{
-        encode: fn {unquote(escape), unquote(encode_map)} ->
+        encode: fn {unquote(escape), unquote(encode_map), unquote(encode_tuple)} ->
           unquote(kv_iodata)
         end
       }
@@ -64,14 +65,15 @@ defmodule Jason.Helpers do
     kv = Enum.map(take, &{&1, generated_var(&1, Codegen)})
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
+    encode_tuple = quote(do: encode_tuple)
+    encode_args = [escape, encode_map, encode_tuple]
     kv_iodata = Codegen.build_kv_iodata(kv, encode_args)
 
     quote do
       case unquote(map) do
         %{unquote_splicing(kv)} ->
           %Fragment{
-            encode: fn {unquote(escape), unquote(encode_map)} ->
+            encode: fn {unquote(escape), unquote(encode_map), unquote(encode_tuple)} ->
               unquote(kv_iodata)
             end
           }

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -117,6 +117,11 @@ defmodule Jason.DecodeTest do
     assert parse!("[1, 2, 3]") == [1, 2, 3]
     assert parse!(~s(["foo", "bar", "baz"])) == ["foo", "bar", "baz"]
     assert parse!(~s([{"foo": "bar"}])) == [%{"foo" => "bar"}]
+
+    assert parse!(~s(["__tuple__"]), tuples: :tuple) == {}
+    assert parse!(~s(["__tuple__",1,2,3]), tuples: :tuple) == {1, 2, 3}
+    assert parse!(~s(["__tuple__"])) == ["__tuple__"]
+    assert parse!(~s(["__tuple__",1,2,3])) == ["__tuple__", 1, 2, 3]
   end
 
   test "whitespace" do

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -65,6 +65,16 @@ defmodule Jason.EncoderTest do
     assert to_json([1, 2, 3]) == "[1,2,3]"
   end
 
+  test "tuple" do
+    assert to_json({}, tuples: :list) == ~s(["__tuple__"])
+    assert to_json({1, 2, 3}, tuples: :list) == ~s(["__tuple__",1,2,3])
+
+    assert_raise EncodeError, "tuple not supported by default, value: {1, 2, 3}. " <>
+                              "To encode tuple, use `tuples: list` option", fn ->
+      to_json({1, 2, 3}, tuple: :raise)
+    end
+  end
+
   test "Time" do
     {:ok, time} = Time.new(12, 13, 14)
     assert to_json(time) == ~s("12:13:14")

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -10,6 +10,9 @@ defmodule Jason.HelpersTest do
     test "produces same output as regular encoding" do
       assert %Fragment{} = helper = json_map(bar: 2, baz: 3, foo: 1)
       assert Jason.encode!(helper) == Jason.encode!(%{bar: 2, baz: 3, foo: 1})
+
+      assert %Fragment{} = helper = json_map(bar: 2,  foo: {1, 2})
+      assert Jason.encode!(helper, tuples: :list) == Jason.encode!(%{bar: 2, foo: {1, 2}}, tuples: :list)
     end
 
     test "rejects keys with invalid characters" do

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -21,6 +21,18 @@ if Code.ensure_loaded?(ExUnitProperties) do
       end
     end
 
+    property "tuple roundtrip" do
+      simple = one_of([integer(), float(), string(:printable), boolean(), nil])
+      json =
+        tree(simple, fn json ->
+          one_of([list_of(json), map_of(string(:printable), json), tuple({json, json})])
+        end)
+
+      check all tuple <- json do
+        assert decode(encode(tuple, tuples: :list), tuples: :tuple)  == tuple
+      end
+    end
+
     property "string-keyed objects roundrtip" do
       check all json <- json(string(:printable)) do
         assert decode(encode(json)) == json


### PR DESCRIPTION
Hi, thanks for package! I suggest to optionally support tuples.

In this request I added option `tuples: :list | :raise (default)` to `Jason.encode/2`, and on `:list` value - tuples would be encoded as lists with meta element "__tuple__" as the list head.   
Also I added `tuples: :tuple | :none (default)` option to `Jason.decode/2`, with `:tuple` value it would decode lists with "__tuple__" element in the head as tuples.

As default, `Jason.encode/2` and `Jason.decode/2` would work same as now.