### PR TITLE
Add :transform_key option to Jason.encode

### DIFF
--- a/lib/codegen.ex
+++ b/lib/codegen.ex
@@ -42,10 +42,10 @@ defmodule Jason.Codegen do
     end
   end
 
-  def build_kv_iodata(kv, encode_args) do
+  def build_kv_iodata(kv, transform_key, encode_args) do
     elements =
       kv
-      |> Enum.map(&encode_pair(&1, encode_args))
+      |> Enum.map(&encode_pair(&1, transform_key, encode_args))
       |> Enum.intersperse(",")
 
     collapse_static(List.flatten(["{", elements] ++ '}'))
@@ -122,8 +122,8 @@ defmodule Jason.Codegen do
     |> :orddict.from_list()
   end
 
-  defp encode_pair({key, value}, encode_args) do
-    key = IO.iodata_to_binary(Encode.key(key, &escape_key/3))
+  defp encode_pair({key, value}, transform_key, encode_args) do
+    key = IO.iodata_to_binary(Encode.key(key, &escape_key/3, transform_key))
     key = "\"" <> key <> "\":"
     [key, quote(do: Encode.value(unquote(value), unquote_splicing(encode_args)))]
   end

--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -21,8 +21,8 @@ defmodule Jason.Encode do
   alias Jason.{Codegen, EncodeError, Encoder, Fragment}
 
   @typep escape :: (String.t, String.t, integer -> iodata)
-  @typep encode_map :: (map, escape, encode_map -> iodata)
   @typep transform_key :: (String.t -> String.t)
+  @typep encode_map :: (map, escape, encode_map, transform_key -> iodata)
   @opaque opts :: {escape, encode_map, transform_key}
 
   # @compile :native
@@ -109,7 +109,7 @@ defmodule Jason.Encode do
   @compile {:inline, integer: 1, float: 1}
 
   @spec atom(atom, opts) :: iodata
-  def atom(atom, {escape, _encode_map}) do
+  def atom(atom, {escape, _encode_map, _transform_key}) do
     encode_atom(atom, escape)
   end
 

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -10,6 +10,8 @@ defprotocol Jason.Encoder do
 
     * `:only` - encodes only values of specified keys.
     * `:except` - encodes all struct fields except specified keys.
+    * `:transform_key` - transforms the keys of the struct by
+      applying the given function.
 
   By default all keys except the `:__struct__` key are encoded.
 

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -82,6 +82,8 @@ defimpl Jason.Encoder, for: Any do
     encode_map = quote(do: encode_map)
     encode_transform_key = quote(do: transform_key)
     encode_args = [escape, encode_map, encode_transform_key]
+    transform_key = Keyword.get(opts, :transform_key)
+    kv_iodata = Jason.Codegen.build_kv_iodata(kv, transform_key, encode_args)
 
     quote do
       defimpl Jason.Encoder, for: unquote(module) do

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -80,14 +80,17 @@ defimpl Jason.Encoder, for: Any do
     kv = Enum.map(fields, &{&1, generated_var(&1, __MODULE__)})
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
-    kv_iodata = Jason.Codegen.build_kv_iodata(kv, encode_args)
+    encode_transform_key = quote(do: transform_key)
+    encode_args = [escape, encode_map, encode_transform_key]
 
     quote do
       defimpl Jason.Encoder, for: unquote(module) do
         require Jason.Helpers
 
-        def encode(%{unquote_splicing(kv)}, {unquote(escape), unquote(encode_map)}) do
+        def encode(%{unquote_splicing(kv)}, {unquote(escape), unquote(encode_map), unquote(encode_transform_key)}) do
+          if unquote(encode_transform_key) != nil do
+            IO.puts("Jason: Be aware that `transform_key` will have no effect on the struct keys.")
+          end
           unquote(kv_iodata)
         end
       end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -34,6 +34,7 @@ defmodule Jason.Helpers do
     encode_map = quote(do: encode_map)
     transform_key = quote(do: transform_key)
     encode_args = [escape, encode_map, transform_key]
+    kv_iodata = Codegen.build_kv_iodata(Macro.expand(kv, __CALLER__), nil, encode_args)
 
     quote do
       %Fragment{
@@ -66,6 +67,7 @@ defmodule Jason.Helpers do
     encode_map = quote(do: encode_map)
     transform_key = quote(do: transform_key)
     encode_args = [escape, encode_map, transform_key]
+    kv_iodata = Codegen.build_kv_iodata(kv, nil, encode_args)
 
     quote do
       case unquote(map) do

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -32,12 +32,12 @@ defmodule Jason.Helpers do
   defmacro json_map(kv) do
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
-    kv_iodata = Codegen.build_kv_iodata(Macro.expand(kv, __CALLER__), encode_args)
+    transform_key = quote(do: transform_key)
+    encode_args = [escape, encode_map, transform_key]
 
     quote do
       %Fragment{
-        encode: fn {unquote(escape), unquote(encode_map)} ->
+        encode: fn {unquote(escape), unquote(encode_map), unquote(transform_key)} ->
           unquote(kv_iodata)
         end
       }
@@ -64,14 +64,14 @@ defmodule Jason.Helpers do
     kv = Enum.map(take, &{&1, generated_var(&1, Codegen)})
     escape = quote(do: escape)
     encode_map = quote(do: encode_map)
-    encode_args = [escape, encode_map]
-    kv_iodata = Codegen.build_kv_iodata(kv, encode_args)
+    transform_key = quote(do: transform_key)
+    encode_args = [escape, encode_map, transform_key]
 
     quote do
       case unquote(map) do
         %{unquote_splicing(kv)} ->
           %Fragment{
-            encode: fn {unquote(escape), unquote(encode_map)} ->
+            encode: fn {unquote(escape), unquote(encode_map), unquote(transform_key)} ->
               unquote(kv_iodata)
             end
           }

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -219,7 +219,7 @@ defmodule Jason do
   end
 
   defp format_encode_opts(opts) do
-    Enum.into(opts, %{escape: :json, maps: :naive})
+    Enum.into(opts, %{escape: :json, maps: :naive, transform_key: nil})
   end
 
   defp format_decode_opts(opts) do

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -110,6 +110,12 @@ defmodule Jason do
       * `true` to pretty print with default configuration
       * a keyword of options as specified by `Jason.Formatter.pretty_print/2`.
 
+    * `:transform_key` - controls how keys in maps or structs are transformed
+
+      * `nil` to not transform the key
+      * a function from string to string which will be applied to the key when
+        encoding
+
   ## Examples
 
       iex> Jason.encode(%{a: 1})
@@ -117,6 +123,9 @@ defmodule Jason do
 
       iex> Jason.encode("\\xFF")
       {:error, %Jason.EncodeError{message: "invalid byte 0xFF in <<255>>"}}
+
+      iex> Jason.encode(%{foo: "bar"}, transform_key: &String.upcase/1)
+      {:ok, ~S|{"FOO":"bar"}|}
 
   """
   @spec encode(term, [encode_opt]) ::


### PR DESCRIPTION
This PR adds an option to `Jason.encode`called `:transform_key`.

The option can either be `nil`, in which case it does nothing, or it can be a function `String.t -> String.t`, which will be applied to any map keys being encoded, before they are escaped.

I have also added the option to the deriving macro for `Jason.Encoder`. However, since the keys are generated at compile time, deriving an encoder, without transforming the keys, and then attempting to encode a struct with `:transform_key` set will not apply the function.
I'm not sure how to handle this in a good way. Currently calling `Jason.encode`, with `:transform_key` set to a function, on a struct with a derived encoder will print out  a warning.

Any suggestions on how to solve this are greatly appreciated.

Fixes #48 

