### PR TITLE
allows for encoding keyword lists

### DIFF
--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -150,6 +150,21 @@ defmodule Jason.Encode do
      | list_loop(tail, escape, encode_map)]
   end
 
+  @spec keyword(keyword, opts) :: iodata
+  def keyword(list, {escape, encode_map}) do
+    keyword(list, escape, encode_map)
+  end
+
+  defp keyword([], _escape, _encode_map) do
+    "{}"
+  end
+
+  defp keyword([{key, value} | tail], escape, encode_map) do
+    ["{\"", key(key, escape), "\":",
+      value(value, escape, encode_map)
+      | map_naive_loop(tail, escape, encode_map)]
+  end
+
   @spec map(map, opts) :: iodata
   def map(value, {escape, encode_map}) do
     encode_map.(value, escape, encode_map)

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -133,6 +133,24 @@ defmodule Jason.EncoderTest do
     assert to_json(derived_using_except) == ~s({"size":10})
   end
 
+  defmodule KeywordTester do
+    defstruct [:baz, :foo, :quux]
+  end
+
+  defimpl Jason.Encoder, for: [KeywordTester] do
+    def encode(struct, opts) do
+      struct
+      |> Map.from_struct
+      |> Enum.map(&(&1))
+      |> Jason.Encode.keyword(opts)
+    end
+  end
+
+  test "using keyword list encoding" do
+    t = %KeywordTester{baz: :bar, foo: "bag", quux: 42}
+    assert to_json(t) == ~s({"baz":"bar","foo":"bag","quux":42})
+  end
+
   test "EncodeError" do
     assert_raise Protocol.UndefinedError, fn ->
       to_json(self())
@@ -163,30 +181,4 @@ defmodule Jason.EncoderTest do
     Jason.encode!(value, opts)
   end
 
-end
-
-defmodule KeywordTester do
-  defstruct [:baz, :foo, :quux]
-end
-
-defimpl Jason.Encoder, for: [KeywordTester] do
-  def encode(struct, opts) do
-    struct
-    |> Map.from_struct
-    |> Enum.map(&(&1))
-    |> Jason.Encode.keyword(opts)
-  end
-end
-
-defmodule Jason.KeywordTest do
-  use ExUnit.Case, async: true
-
-  test "using keyword list encoding" do
-    t = %KeywordTester{baz: :bar, foo: "bag", quux: 42}
-    assert to_json(t) == ~s({"baz":"bar","foo":"bag","quux":42})
-  end
-
-  defp to_json(value, opts \\ []) do
-    Jason.encode!(value, opts)
-  end
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -162,4 +162,31 @@ defmodule Jason.EncoderTest do
   defp to_json(value, opts \\ []) do
     Jason.encode!(value, opts)
   end
+
+end
+
+defmodule KeywordTester do
+  defstruct [:baz, :foo, :quux]
+end
+
+defimpl Jason.Encoder, for: [KeywordTester] do
+  def encode(struct, opts) do
+    struct
+    |> Map.from_struct
+    |> Enum.map(&(&1))
+    |> Jason.Encode.keyword(opts)
+  end
+end
+
+defmodule Jason.KeywordTest do
+  use ExUnit.Case, async: true
+
+  test "using keyword list encoding" do
+    t = %KeywordTester{baz: :bar, foo: "bag", quux: 42}
+    assert to_json(t) == ~s({"baz":"bar","foo":"bag","quux":42})
+  end
+
+  defp to_json(value, opts \\ []) do
+    Jason.encode!(value, opts)
+  end
 end


### PR DESCRIPTION
This is useful if one wants to do:
```
%Struct{...}
|> Map.from_struct
|> Enum.<tranformation1>
|> Enum.<transformation2>
|> Jason.Encode.keyword(opts)
```
inside of a `defimpl`, which lets you segregate all of your JSON marshalling to an external API in one place.

Pros:
No need to do a costly `Enum.into(%{})` only to `Map.to_list()` later anyways.

Cons:
Introduces a guard into the passed encode_map() function, there may be a performance hit that everyone pays. Seems mostly useful for only a small subset of Ecto schema transformations (where you are `defimpl`'ing externally).

Refactoring opportunities:
Might consider DRYing keyword_naive/map_naive, keyword_strict/map_strict into a single function and guarding Map.to_list instead.
