### PR TITLE
Encode decimals without quotes

### DIFF
--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -236,7 +236,7 @@ defmodule Jason.Encode do
   defp struct(value, _escape, _encode_map, Decimal) do
     # silence the xref warning
     decimal = Decimal
-    [?\", decimal.to_string(value, :normal), ?\"]
+    decimal.to_string(value, :normal)
   end
 
   defp struct(value, escape, encode_map, Fragment) do

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -205,7 +205,7 @@ defimpl Jason.Encoder, for: Decimal do
   def encode(value, _opts) do
     # silence the xref warning
     decimal = Decimal
-    [?\", decimal.to_string(value), ?\"]
+    decimal.to_string(value, :normal)
   end
 end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -94,7 +94,10 @@ defmodule Jason.EncoderTest do
 
   test "Decimal" do
     decimal = Decimal.new("1.0")
-    assert to_json(decimal) == ~s("1.0")
+    assert to_json(decimal) == "1.0"
+ 
+    decimal = Decimal.new("123e1")
+    assert to_json(decimal) == "1230"
   end
 
   defmodule Derived do


### PR DESCRIPTION
As stated in Issue #71, Jason is currently encoding Decimal values as strings (in fact, quoted floats).

Since Decimals are no less (or much more) than a number with (possibly) a fractional part, Jason should not mistreat them and convert them to string representation.

Additionally, there is a fix for `Encoder.encode`, where it could produce numbers in scientific notation on encoding (i.e., _123e1_).