### PR TITLE
Support :decimals mode

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -44,7 +44,7 @@ defmodule Jason.Decoder do
     key_decode = key_decode_function(opts)
     string_decode = string_decode_function(opts)
     try do
-      value(data, data, 0, [@terminate], key_decode, string_decode)
+      value(data, data, 0, [@terminate], key_decode, string_decode, opts[:decimals])
     catch
       {:position, position} ->
         {:error, %DecodeError{position: position, data: data}}
@@ -64,202 +64,204 @@ defmodule Jason.Decoder do
   defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
   defp string_decode_function(%{strings: :reference}), do: &(&1)
 
-  defp value(data, original, skip, stack, key_decode, string_decode) do
+  defp value(data, original, skip, stack, key_decode, string_decode, num_decode_mode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        value(rest, original, skip + 1, stack, key_decode, string_decode)
+        value(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       _ in '0', rest ->
-        number_zero(rest, original, skip, stack, key_decode, string_decode, 1)
+        number_zero(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, 1)
       _ in '123456789', rest ->
-        number(rest, original, skip, stack, key_decode, string_decode, 1)
+        number(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, 1)
       _ in '-', rest ->
-        number_minus(rest, original, skip, stack, key_decode, string_decode)
+        number_minus(rest, original, skip, stack, key_decode, string_decode, num_decode_mode)
       _ in '"', rest ->
-        string(rest, original, skip + 1, stack, key_decode, string_decode, 0)
+        string(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, 0)
       _ in '[', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       _ in '{', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       _ in ']', rest ->
-        empty_array(rest, original, skip + 1, stack, key_decode, string_decode)
+        empty_array(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       _ in 't', rest ->
         case rest do
           <<"rue", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, true)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, num_decode_mode, true)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'f', rest ->
         case rest do
           <<"alse", rest::bits>> ->
-            continue(rest, original, skip + 5, stack, key_decode, string_decode, false)
+            continue(rest, original, skip + 5, stack, key_decode, string_decode, num_decode_mode, false)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'n', rest ->
         case rest do
           <<"ull", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, nil)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, num_decode_mode, nil)
           <<_::bits>> ->
             error(original, skip)
         end
       _, rest ->
-        error(rest, original, skip + 1, stack, key_decode, string_decode)
+        error(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       <<_::bits>> ->
         error(original, skip)
     end
   end
 
-  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    number_zero(rest, original, skip, stack, key_decode, string_decode, 2)
+  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode) do
+    number_zero(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, 2)
   end
-  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode)
+  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode)
        when byte in '123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, 2)
+    number(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, 2)
   end
-  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode) do
+  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode) do
     error(original, skip + 1)
   end
 
-  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
+  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) when e in 'eE' do
     prefix = binary_part(original, skip, len)
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, prefix)
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, num_decode_mode, prefix)
   end
-  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    int = String.to_integer(binary_part(original, skip, len))
-    continue(rest, original, skip + len, stack, key_decode, string_decode, int)
+  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
+    int = parse_integer(binary_part(original, skip, len), num_decode_mode)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, int)
   end
 
-  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, len) do
     error(original, skip + len)
   end
 
-  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when e in 'eE' do
-    number_exp(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
     token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    float = try_parse_float(token, token, skip, num_decode_mode)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, float)
   end
 
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
     token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    float = try_parse_float(token, token, skip, num_decode_mode)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, float)
   end
 
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, 1)
   end
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, 1)
   end
-  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix) do
+  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, _prefix) do
     error(original, skip)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, _prefix, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, prefix, len) do
     suffix = binary_part(original, skip, len)
     string = prefix <> ".0e" <> suffix
     prefix_size = byte_size(prefix)
     initial_skip = skip - prefix_size - 1
     final_skip = skip + len
     token = binary_part(original, initial_skip, prefix_size + len + 1)
-    float = try_parse_float(string, token, initial_skip)
-    continue(rest, original, final_skip, stack, key_decode, string_decode, float)
+    float = try_parse_float(string, token, initial_skip, num_decode_mode)
+    continue(rest, original, final_skip, stack, key_decode, string_decode, num_decode_mode, float)
   end
 
-  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
   end
-  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, "0")
+  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) when e in 'eE' do
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, num_decode_mode, "0")
   end
-  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    continue(rest, original, skip + len, stack, key_decode, string_decode, 0)
+  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
+    continue(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, number_zero(0, num_decode_mode))
+  end
+  defp number_zero(0, :all), do: Decimal.new(0)
+  defp number_zero(0, _), do: 0
+
+  @compile {:inline, array: 7}
+
+  defp array(rest, original, skip, stack, key_decode, string_decode, num_decode_mode) do
+    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode, num_decode_mode)
   end
 
-  @compile {:inline, array: 6}
-
-  defp array(rest, original, skip, stack, key_decode, string_decode) do
-    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode)
-  end
-
-  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode) do
+  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode) do
     case stack do
       [@array, [] | stack] ->
-        continue(rest, original, skip, stack, key_decode, string_decode, [])
+        continue(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, [])
       _ ->
         error(original, skip - 1)
     end
   end
 
-  defp array(data, original, skip, stack, key_decode, string_decode, value) do
+  defp array(data, original, skip, stack, key_decode, string_decode, num_decode_mode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, value)
       _ in ']', rest ->
         [acc | stack] = stack
         value = :lists.reverse(acc, [value])
-        continue(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        continue(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, value)
       _ in ',', rest ->
         [acc | stack] = stack
-        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode, num_decode_mode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -267,26 +269,26 @@ defmodule Jason.Decoder do
     end
   end
 
-  @compile {:inline, object: 6}
+  @compile {:inline, object: 7}
 
-  defp object(rest, original, skip, stack, key_decode, string_decode) do
-    key(rest, original, skip, [[] | stack], key_decode, string_decode)
+  defp object(rest, original, skip, stack, key_decode, string_decode, num_decode_mode) do
+    key(rest, original, skip, [[] | stack], key_decode, string_decode, num_decode_mode)
   end
 
-  defp object(data, original, skip, stack, key_decode, string_decode, value) do
+  defp object(data, original, skip, stack, key_decode, string_decode, num_decode_mode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, value)
       _ in '}', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         final = [{key_decode.(key), value} | acc]
-        continue(rest, original, skip, stack, key_decode, string_decode, :maps.from_list(final))
+        continue(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, :maps.from_list(final))
       _ in ',', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         acc = [{key_decode.(key), value} | acc]
-        key(rest, original, skip, [acc | stack], key_decode, string_decode)
+        key(rest, original, skip, [acc | stack], key_decode, string_decode, num_decode_mode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -294,19 +296,19 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode) do
+  defp key(data, original, skip, stack, key_decode, string_decode, num_decode_mode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode)
       _ in '}', rest ->
         case stack do
           [[] | stack] ->
-            continue(rest, original, skip + 1, stack, key_decode, string_decode, %{})
+            continue(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, %{})
           _ ->
             error(original, skip)
         end
       _ in '"', rest ->
-        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, 0)
+        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, num_decode_mode, 0)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -314,12 +316,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, key_decode, string_decode, num_decode_mode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, value)
       _ in ':', rest ->
-        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode, num_decode_mode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -330,73 +332,73 @@ defmodule Jason.Decoder do
   # TODO: check if this approach would be faster:
   # https://git.ninenines.eu/cowlib.git/tree/src/cow_ws.erl#n469
   # http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
-  defp string(data, original, skip, stack, key_decode, string_decode, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, num_decode_mode, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         string = string_decode.(binary_part(original, skip, len))
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, num_decode_mode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, part)
+        escape(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, part)
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp string(data, original, skip, stack, key_decode, string_decode, acc, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         last = binary_part(original, skip, len)
         string = IO.iodata_to_binary([acc | last])
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, num_decode_mode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, [acc | part])
+        escape(rest, original, skip + len, stack, key_decode, string_decode, num_decode_mode, [acc | part])
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp escape(data, original, skip, stack, key_decode, string_decode, acc) do
+  defp escape(data, original, skip, stack, key_decode, string_decode, num_decode_mode, acc) do
     bytecase data do
       _ in 'b', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\b'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\b'], 0)
       _ in 't', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\t'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\t'], 0)
       _ in 'n', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\n'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\n'], 0)
       _ in 'f', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\f'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\f'], 0)
       _ in 'r', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\r'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\r'], 0)
       _ in '"', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\"'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\"'], 0)
       _ in '/', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '/'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '/'], 0)
       _ in '\\', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\\'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, num_decode_mode, [acc | '\\'], 0)
       _ in 'u', rest ->
-        escapeu(rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
       _, _rest ->
         error(original, skip + 1)
       <<_::bits>> ->
@@ -432,8 +434,8 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, acc) do
-      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -441,20 +443,20 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc) do
+    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc) do
       for {int, first} <- unicode_escapes(),
           not (first in 0xDC..0xDF) do
-        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
       end
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
          when first in 0xD8..0xDB do
       hi =
         quote bind_quoted: [first: first, last: last] do
           0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, hi]
+      args = [rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi]
       [clause] =
         quote location: :keep do
           unquote(int) -> escape_surrogate(unquote_splicing(args))
@@ -462,7 +464,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
          when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -477,7 +479,7 @@ defmodule Jason.Decoder do
             [acc, byte1, byte2]
           end
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -485,7 +487,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
          when first <= 0x07 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -495,7 +497,7 @@ defmodule Jason.Decoder do
           byte2 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -503,7 +505,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
          when first <= 0xFF do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -514,7 +516,7 @@ defmodule Jason.Decoder do
           byte3 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2, byte3]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -541,9 +543,9 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -551,22 +553,22 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi) do
       digits1 = 'Dd'
       digits2 = Stream.concat([?C..?F, ?c..?f])
       for {int, first} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi)
       end
     end
 
-    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi) do
       skip = quote do: unquote(skip) + 12
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
           lo = ((first &&& 0x03) <<< 8) + last
           [acc | <<(hi + lo)::utf8>>]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
@@ -576,12 +578,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, acc) do
     require Unescape
     last = escapeu_last(int2, original, skip)
-    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc)
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc) do
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, _acc) do
     empty_error(original, skip)
   end
 
@@ -593,23 +595,32 @@ defmodule Jason.Decoder do
   end
 
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
-       skip, stack, key_decode, string_decode, acc, hi) do
+       skip, stack, key_decode, string_decode, num_decode_mode, acc, hi) do
     require Unescape
     last = escapeu_last(int2, original, skip + 6)
-    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, num_decode_mode, acc, hi)
   end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc, _hi) do
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, _acc, _hi) do
     error(original, skip + 6)
   end
 
-  defp try_parse_float(string, token, skip) do
+  defp parse_integer(string, :all), do: Decimal.new(string)
+  defp parse_integer(string, _), do: String.to_integer(string)
+
+  defp try_parse_float(string, token, skip, num_decode_mode) when num_decode_mode in [:all, :floats] do
+    case Decimal.parse(string) do
+      {:ok, decimal} -> decimal
+      _ -> token_error(token, skip)
+    end
+  end
+  defp try_parse_float(string, token, skip, _) do
     :erlang.binary_to_float(string)
   catch
     :error, :badarg ->
       token_error(token, skip)
   end
 
-  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode) do
+  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode, _num_decode_mode) do
     throw {:position, skip - 1}
   end
 
@@ -630,28 +641,28 @@ defmodule Jason.Decoder do
     throw {:token, binary_part(token, position, len), position}
   end
 
-  @compile {:inline, continue: 7}
-  defp continue(rest, original, skip, stack, key_decode, string_decode, value) do
+  @compile {:inline, continue: 8}
+  defp continue(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, value) do
     case stack do
       [@terminate | stack] ->
-        terminate(rest, original, skip, stack, key_decode, string_decode, value)
+        terminate(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, value)
       [@array | stack] ->
-        array(rest, original, skip, stack, key_decode, string_decode, value)
+        array(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, value)
       [@key | stack] ->
-        key(rest, original, skip, stack, key_decode, string_decode, value)
+        key(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, value)
       [@object | stack] ->
-        object(rest, original, skip, stack, key_decode, string_decode, value)
+        object(rest, original, skip, stack, key_decode, string_decode, num_decode_mode, value)
     end
   end
 
-  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, value)
+  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, num_decode_mode, value)
        when byte in '\s\n\r\t' do
-    terminate(rest, original, skip + 1, stack, key_decode, string_decode, value)
+    terminate(rest, original, skip + 1, stack, key_decode, string_decode, num_decode_mode, value)
   end
-  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, value) do
+  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, _num_decode_mode, value) do
     value
   end
-  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _value) do
+  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _num_decode_mode, _value) do
     error(original, skip)
   end
 end

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -14,7 +14,9 @@ defmodule Jason do
 
   @type strings :: :reference | :copy
 
-  @type decode_opt :: {:keys, keys} | {:strings, strings}
+  @type decimals :: :none | :floats | :all
+
+  @type decode_opt :: {:keys, keys} | {:strings, strings} | {:decimals, decimals}
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -36,6 +38,14 @@ defmodule Jason do
         decoded data will be stored for a long time (in ets or some process) to avoid keeping
         the reference to the original data.
 
+    * `:decimals` - allows numbers to be decoded as `Decimal`. Possible values are:
+
+      * `:none` (default) - numbers are decoded as `float` or `integer` (depending on
+        presence or lack of decimal point),
+      * `:floats` - decimal values only will be presented as `Decimal` (i.e., "1.0", "1e1"
+        will be `float`; "1" will be `integer`),
+      * `:all` - any number will be decoded as `Decimal`.
+
   ## Decoding keys to atoms
 
   The `:atoms` option uses the `String.to_atom/1` call that can create atoms at runtime.
@@ -49,6 +59,10 @@ defmodule Jason do
 
       iex> Jason.decode("invalid")
       {:error, %Jason.DecodeError{data: "invalid", position: 0, token: nil}}
+
+      iex> {:ok, json} = Jason.decode(~s({"foo":1}), decimals: :all)
+      iex> json["foo"]
+      #Decimal<1>
   """
   @spec decode(iodata, [decode_opt]) :: {:ok, term} | {:error, DecodeError.t()}
   def decode(input, opts \\ []) do
@@ -223,6 +237,6 @@ defmodule Jason do
   end
 
   defp format_decode_opts(opts) do
-    Enum.into(opts, %{keys: :strings, strings: :reference})
+    Enum.into(opts, %{keys: :strings, strings: :reference, decimals: :none})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,7 @@ defmodule Jason.Mixfile do
 
   defp dialyzer() do
     [
+      plt_add_apps: [:decimal],
       ignore_warnings: "dialyzer.ignore"
     ]
   end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -108,6 +108,44 @@ defmodule Jason.DecodeTest do
     assert parse!(~s({"FOO": "bar"}), keys: &String.downcase/1) == %{"foo" => "bar"}
   end
 
+  test "decimals mode tests" do
+    # decimals: :none
+    assert parse!("{}", decimals: :none) === %{}
+    assert parse!(~s({"foo": 1}), decimals: :none) === %{"foo" => 1}
+    assert parse!(~s({"foo": 1.0}), decimals: :none) === %{"foo" => 1.0}
+    assert parse!(~s({"foo": 1e1}), decimals: :none) === %{"foo" => 10.0}
+    assert parse!(~s({"foo": -1}), decimals: :none) === %{"foo" => -1}
+    assert parse!(~s({"foo": -1.0}), decimals: :none) === %{"foo" => -1.0}
+    assert parse!(~s({"foo": -1e1}), decimals: :none) === %{"foo" => -10.0}
+    assert parse!(~s({"foo": 1e-1}), decimals: :none) === %{"foo" => 0.1}
+    assert parse!(~s({"foo": 0.0}), decimals: :none) === %{"foo" => 0.0}
+    assert parse!(~s({"foo": -0}), decimals: :none) === %{"foo" => 0}
+
+    # decimals: :floats
+    assert parse!("{}", decimals: :floats) === %{}
+    assert parse!(~s({"foo": 1}), decimals: :floats) === %{"foo" => 1}
+    assert parse!(~s({"foo": 1.0}), decimals: :floats) === %{"foo" => Decimal.new("1.0")}
+    assert parse!(~s({"foo": 1e1}), decimals: :floats) === %{"foo" => Decimal.new("10")}
+    assert parse!(~s({"foo": -1}), decimals: :floats) === %{"foo" => -1}
+    assert parse!(~s({"foo": -1.0}), decimals: :floats) === %{"foo" => Decimal.new("-1.0")}
+    assert parse!(~s({"foo": -1e1}), decimals: :floats) === %{"foo" => Decimal.new("-10")}
+    assert parse!(~s({"foo": 1e-1}), decimals: :floats) === %{"foo" => Decimal.new("0.10")}
+    assert parse!(~s({"foo": 0.0}), decimals: :floats) === %{"foo" => Decimal.new("0.0")}
+    assert parse!(~s({"foo": -0}), decimals: :floats) === %{"foo" => 0}
+
+    # decimals: :all
+    assert parse!("{}", decimals: :all) === %{}
+    assert parse!(~s({"foo": 1}), decimals: :all) === %{"foo" => Decimal.new("1")}
+    assert parse!(~s({"foo": 1.0}), decimals: :all) === %{"foo" => Decimal.new("1.0")}
+    assert parse!(~s({"foo": 1e1}), decimals: :all) === %{"foo" => Decimal.new("10")}
+    assert parse!(~s({"foo": -1}), decimals: :all) === %{"foo" => Decimal.new("-1")}
+    assert parse!(~s({"foo": -1.0}), decimals: :all) === %{"foo" => Decimal.new("-1.0")}
+    assert parse!(~s({"foo": -1e1}), decimals: :all) === %{"foo" => Decimal.new("-10")}
+    assert parse!(~s({"foo": 1e-1}), decimals: :all) === %{"foo" => Decimal.new("0.10")}
+    assert parse!(~s({"foo": 0.0}), decimals: :all) === %{"foo" => Decimal.new("0.0")}
+    assert parse!(~s({"foo": -0}), decimals: :all) === %{"foo" => Decimal.new("0")}
+  end
+
   test "arrays" do
     assert_fail_with "[", "unexpected end of input at position 1"
     assert_fail_with "[,", "unexpected byte at position 1: 0x2C (',')"


### PR DESCRIPTION
Introduce `:decimals` decoding option. Allows to produce decoded maps where integers/floats are represented with a `Decimal` struct. Supported options are:
- :none - current behaviour
- :floats - values currently parsed by `try_parse_float` are turned to `Decimal`
- :all - any number (`parse_integer` or `try_parse_float` in current implementation) will be parsed to `Decimal`

**Implementation notes**: I've selected to use function argument matching to get the desired result where I had to propagate one argument (`num_decode_mode`) throughout the code. The other approach was to propagate two functions (float and integer parsing), but I simply liked the first approach more.

On performance impact, I am not sure how much of a change there really is. My dev machine was all over the place for both original and new implementation.