### PR TITLE
Update encode_opt typespec for pretty: false

### DIFF
--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -8,7 +8,7 @@ defmodule Jason do
   @type escape :: :json | :unicode_safe | :html_safe | :javascript_safe
   @type maps :: :naive | :strict
 
-  @type encode_opt :: {:escape, escape} | {:maps, maps} | {:pretty, true | Formatter.opts()}
+  @type encode_opt :: {:escape, escape} | {:maps, maps} | {:pretty, boolean | Formatter.opts()}
 
   @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> term)
 


### PR DESCRIPTION
I have a case where I want to be sure of the JSON not being pretty, so I would like to pass `pretty: false`. The support for this option was added in #58 as response to issue #54, but the typespec was not changed, so Dialyzer is yelling at me for using `pretty: false`, despite it being okay.

This should fix it :)