### PR TITLE
enable nested keyword list encoding

### DIFF
--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -89,7 +89,12 @@ defmodule Jason.Encode do
   end
 
   def value(value, escape, encode_map) when is_list(value) do
-    list(value, escape, encode_map)
+    cond do
+      Keyword.keyword?(value) and length(value) > 0 ->
+        keyword(value, {escape, encode_map})
+      true ->
+        list(value, escape, encode_map)
+    end
   end
 
   def value(%{__struct__: module} = value, escape, encode_map) do

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -151,6 +151,11 @@ defmodule Jason.EncoderTest do
     assert to_json(t) == ~s({"baz":"bar","foo":"bag","quux":42})
   end
 
+  test "nested keyword list" do
+    d = %{map: [containing: "a", keyword: "list"]}
+    assert to_json(d) == ~s({"map":{"containing":"a","keyword":"list"}})
+  end
+
   test "EncodeError" do
     assert_raise Protocol.UndefinedError, fn ->
       to_json(self())


### PR DESCRIPTION
Currently, keyword lists can only be encoded explicitly.  Attempting to encode a data structure that includes a nested keyword list will fail with a protocol not implemented error once it reaches the Tuple level.  This change allows detecting nested keyword lists and delegating to the current encoding implementation.