### PR TITLE
Add strict opts on decode

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -1,14 +1,20 @@
 defmodule Jason.DecodeError do
-  @type t :: %__MODULE__{position: integer, data: String.t}
+  @type t :: %__MODULE__{position: integer, data: String.t, key: String.t}
 
-  defexception [:position, :token, :data]
+  defexception [:position, :token, :data, :key]
+
+  def message(%{key: key}) when is_binary(key) do
+    "duplicate key: #{key}"
+  end
 
   def message(%{position: position, token: token}) when is_binary(token) do
     "unexpected sequence at position #{position}: #{inspect token}"
   end
+
   def message(%{position: position, data: data}) when position == byte_size(data) do
     "unexpected end of input at position #{position}"
   end
+
   def message(%{position: position, data: data}) do
     byte = :binary.at(data, position)
     str = <<byte>>
@@ -41,18 +47,262 @@ defmodule Jason.Decoder do
   @object    3
 
   def parse(data, opts) when is_binary(data) do
-    key_decode = key_decode_function(opts)
-    string_decode = string_decode_function(opts)
     try do
-      value(data, data, 0, [@terminate], key_decode, string_decode)
+      value(data, data, 0, [@terminate], opts)
     catch
       {:position, position} ->
         {:error, %DecodeError{position: position, data: data}}
       {:token, token, position} ->
         {:error, %DecodeError{token: token, position: position, data: data}}
+      {:duplicate_key, key} ->
+        {:error, %DecodeError{key: key}}
     else
       value ->
         {:ok, value}
+    end
+  end
+
+  defp value(data, original, skip, stack, opts) do
+    bytecase data do
+      _ in '\s\n\t\r', rest ->
+        value(rest, original, skip + 1, stack, opts)
+      _ in '0', rest ->
+        number_zero(rest, original, skip, stack, opts, 1)
+      _ in '123456789', rest ->
+        number(rest, original, skip, stack, opts, 1)
+      _ in '-', rest ->
+        number_minus(rest, original, skip, stack, opts)
+      _ in '"', rest ->
+        string(rest, original, skip + 1, stack, opts, 0)
+      _ in '[', rest ->
+        array(rest, original, skip + 1, stack, opts)
+      _ in '{', rest ->
+        object(rest, original, skip + 1, stack, opts)
+      _ in ']', rest ->
+        empty_array(rest, original, skip + 1, stack, opts)
+      _ in 't', rest ->
+        case rest do
+          <<"rue", rest::bits>> ->
+            continue(rest, original, skip + 4, stack, opts, true)
+          <<_::bits>> ->
+            error(original, skip)
+        end
+      _ in 'f', rest ->
+        case rest do
+          <<"alse", rest::bits>> ->
+            continue(rest, original, skip + 5, stack, opts, false)
+          <<_::bits>> ->
+            error(original, skip)
+        end
+      _ in 'n', rest ->
+        case rest do
+          <<"ull", rest::bits>> ->
+            continue(rest, original, skip + 4, stack, opts, nil)
+          <<_::bits>> ->
+            error(original, skip)
+        end
+      _, rest ->
+        error(rest, original, skip + 1, stack, opts)
+      <<_::bits>> ->
+        error(original, skip)
+    end
+  end
+
+  defp number_minus(<<?0, rest::bits>>, original, skip, stack, opts) do
+    number_zero(rest, original, skip, stack, opts, 2)
+  end
+
+  defp number_minus(<<byte, rest::bits>>, original, skip, stack, opts)
+       when byte in '123456789' do
+    number(rest, original, skip, stack, opts, 2)
+  end
+
+  defp number_minus(<<_rest::bits>>, original, skip, _stack, _opts) do
+    error(original, skip + 1)
+  end
+
+  defp number(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number(<<?., rest::bits>>, original, skip, stack, opts, len) do
+    number_frac(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number(<<e, rest::bits>>, original, skip, stack, opts, len) when e in 'eE' do
+    prefix = binary_part(original, skip, len)
+    number_exp_copy(rest, original, skip + len + 1, stack, opts, prefix)
+  end
+
+  defp number(<<rest::bits>>, original, skip, stack, opts, len) do
+    int = String.to_integer(binary_part(original, skip, len))
+    continue(rest, original, skip + len, stack, opts, int)
+  end
+
+  defp number_frac(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number_frac_cont(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number_frac(<<_rest::bits>>, original, skip, _stack, _opts, len) do
+    error(original, skip + len)
+  end
+
+  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number_frac_cont(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, opts, len)
+       when e in 'eE' do
+    number_exp(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number_frac_cont(<<rest::bits>>, original, skip, stack, opts, len) do
+    token = binary_part(original, skip, len)
+    float = try_parse_float(token, token, skip)
+    continue(rest, original, skip + len, stack, opts, float)
+  end
+
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '+-' do
+    number_exp_sign(rest, original, skip, stack, opts, len + 1)
+  end
+
+  defp number_exp(<<_rest::bits>>, original, skip, _stack, _opts, len) do
+    error(original, skip + len)
+  end
+
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, len + 1)
+  end
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _opts, len) do
+    error(original, skip + len)
+  end
+
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, opts, len)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, len + 1)
+  end
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, opts, len) do
+    token = binary_part(original, skip, len)
+    float = try_parse_float(token, token, skip)
+    continue(rest, original, skip + len, stack, opts, float)
+  end
+
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, opts, prefix)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, prefix, 1)
+  end
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, opts, prefix)
+       when byte in '+-' do
+    number_exp_sign(rest, original, skip, stack, opts, prefix, 1)
+  end
+  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _opts, _prefix) do
+    error(original, skip)
+  end
+
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, opts, prefix, len)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, prefix, len + 1)
+  end
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _opts, _prefix, len) do
+    error(original, skip + len)
+  end
+
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, opts, prefix, len)
+       when byte in '0123456789' do
+    number_exp_cont(rest, original, skip, stack, opts, prefix, len + 1)
+  end
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, opts, prefix, len) do
+    suffix = binary_part(original, skip, len)
+    string = prefix <> ".0e" <> suffix
+    prefix_size = byte_size(prefix)
+    initial_skip = skip - prefix_size - 1
+    final_skip = skip + len
+    token = binary_part(original, initial_skip, prefix_size + len + 1)
+    float = try_parse_float(string, token, initial_skip)
+    continue(rest, original, final_skip, stack, opts, float)
+  end
+
+  defp number_zero(<<?., rest::bits>>, original, skip, stack, opts, len) do
+    number_frac(rest, original, skip, stack, opts, len + 1)
+  end
+  defp number_zero(<<e, rest::bits>>, original, skip, stack, opts, len) when e in 'eE' do
+    number_exp_copy(rest, original, skip + len + 1, stack, opts, "0")
+  end
+  defp number_zero(<<rest::bits>>, original, skip, stack, opts, len) do
+    continue(rest, original, skip + len, stack, opts, 0)
+  end
+
+  @compile {:inline, array: 5}
+
+  defp array(rest, original, skip, stack, opts) do
+    value(rest, original, skip, [@array, [] | stack], opts)
+  end
+
+  defp empty_array(<<rest::bits>>, original, skip, stack, opts) do
+    case stack do
+      [@array, [] | stack] ->
+        continue(rest, original, skip, stack, opts, [])
+      _ ->
+        error(original, skip - 1)
+    end
+  end
+
+  defp array(data, original, skip, stack, opts, value) do
+    bytecase data do
+      _ in '\s\n\t\r', rest ->
+        array(rest, original, skip + 1, stack, opts, value)
+      _ in ']', rest ->
+        [acc | stack] = stack
+        value = :lists.reverse(acc, [value])
+        continue(rest, original, skip + 1, stack, opts, value)
+      _ in ',', rest ->
+        [acc | stack] = stack
+        value(rest, original, skip + 1, [@array, [value | acc] | stack], opts)
+      _, _rest ->
+        error(original, skip)
+      <<_::bits>> ->
+        empty_error(original, skip)
+    end
+  end
+
+  @compile {:inline, object: 5}
+
+  defp object(rest, original, skip, stack, opts) do
+    key(rest, original, skip, [[] | stack], opts)
+  end
+
+  defp object(data, original, skip, stack, opts, value) do
+    key_decode = key_decode_function(opts)
+    map_decode = decode_map_function(opts)
+
+    bytecase data do
+      _ in '\s\n\t\r', rest ->
+        object(rest, original, skip + 1, stack, opts, value)
+      _ in '}', rest ->
+        skip = skip + 1
+        [key, acc | stack] = stack
+        final = [{key_decode.(key), value} | acc]
+        map_decode.(final, length(final))
+        continue(rest, original, skip, stack, opts, :maps.from_list(final))
+      _ in ',', rest ->
+        skip = skip + 1
+        [key, acc | stack] = stack
+        acc = [{key_decode.(key), value} | acc]
+        key(rest, original, skip, [acc | stack], opts)
+      _, _rest ->
+        error(original, skip)
+      <<_::bits>> ->
+        empty_error(original, skip)
     end
   end
 
@@ -61,252 +311,41 @@ defmodule Jason.Decoder do
   defp key_decode_function(%{keys: :strings}), do: &(&1)
   defp key_decode_function(%{keys: fun}) when is_function(fun, 1), do: fun
 
-  defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
-  defp string_decode_function(%{strings: :reference}), do: &(&1)
-
-  defp value(data, original, skip, stack, key_decode, string_decode) do
-    bytecase data do
-      _ in '\s\n\t\r', rest ->
-        value(rest, original, skip + 1, stack, key_decode, string_decode)
-      _ in '0', rest ->
-        number_zero(rest, original, skip, stack, key_decode, string_decode, 1)
-      _ in '123456789', rest ->
-        number(rest, original, skip, stack, key_decode, string_decode, 1)
-      _ in '-', rest ->
-        number_minus(rest, original, skip, stack, key_decode, string_decode)
-      _ in '"', rest ->
-        string(rest, original, skip + 1, stack, key_decode, string_decode, 0)
-      _ in '[', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode)
-      _ in '{', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode)
-      _ in ']', rest ->
-        empty_array(rest, original, skip + 1, stack, key_decode, string_decode)
-      _ in 't', rest ->
-        case rest do
-          <<"rue", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, true)
-          <<_::bits>> ->
-            error(original, skip)
-        end
-      _ in 'f', rest ->
-        case rest do
-          <<"alse", rest::bits>> ->
-            continue(rest, original, skip + 5, stack, key_decode, string_decode, false)
-          <<_::bits>> ->
-            error(original, skip)
-        end
-      _ in 'n', rest ->
-        case rest do
-          <<"ull", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, nil)
-          <<_::bits>> ->
-            error(original, skip)
-        end
-      _, rest ->
-        error(rest, original, skip + 1, stack, key_decode, string_decode)
-      <<_::bits>> ->
-        error(original, skip)
+  defp decode_map_function(%{maps: maps}) do
+    case maps do
+      :strict -> &map_strict/2
     end
   end
 
-  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    number_zero(rest, original, skip, stack, key_decode, string_decode, 2)
-  end
-  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode)
-       when byte in '123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, 2)
-  end
-  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode) do
-    error(original, skip + 1)
-  end
+  defp decode_map_function(_), do: fn _, _ -> true end
 
-  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    prefix = binary_part(original, skip, len)
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, prefix)
-  end
-  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    int = String.to_integer(binary_part(original, skip, len))
-    continue(rest, original, skip + len, stack, key_decode, string_decode, int)
-  end
+  defp map_strict(values, total_expected), do: map_strict_loop(values, total_expected, :sets.new)
 
-  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
-    error(original, skip + len)
-  end
+  defp map_strict_loop([], _total_expected, _set), do: true
 
-  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when e in 'eE' do
-    number_exp(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
-  end
+  defp map_strict_loop([{key, _value} | tail], total_expected, set) do
+    set = :sets.add_element(key, set)
 
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
-    error(original, skip + len)
-  end
-
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
-    error(original, skip + len)
-  end
-
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
-  end
-
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
-  end
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
-       when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
-  end
-  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix) do
-    error(original, skip)
-  end
-
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
-  end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix, len) do
-    error(original, skip + len)
-  end
-
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
-       when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
-  end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len) do
-    suffix = binary_part(original, skip, len)
-    string = prefix <> ".0e" <> suffix
-    prefix_size = byte_size(prefix)
-    initial_skip = skip - prefix_size - 1
-    final_skip = skip + len
-    token = binary_part(original, initial_skip, prefix_size + len + 1)
-    float = try_parse_float(string, token, initial_skip)
-    continue(rest, original, final_skip, stack, key_decode, string_decode, float)
-  end
-
-  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
-  end
-  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, "0")
-  end
-  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    continue(rest, original, skip + len, stack, key_decode, string_decode, 0)
-  end
-
-  @compile {:inline, array: 6}
-
-  defp array(rest, original, skip, stack, key_decode, string_decode) do
-    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode)
-  end
-
-  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    case stack do
-      [@array, [] | stack] ->
-        continue(rest, original, skip, stack, key_decode, string_decode, [])
-      _ ->
-        error(original, skip - 1)
+    if :sets.size(set) + length(tail) == total_expected do
+      map_strict_loop(tail, total_expected, set)
+    else
+      duplicate_key_error(key)
     end
   end
 
-  defp array(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, opts) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode, value)
-      _ in ']', rest ->
-        [acc | stack] = stack
-        value = :lists.reverse(acc, [value])
-        continue(rest, original, skip + 1, stack, key_decode, string_decode, value)
-      _ in ',', rest ->
-        [acc | stack] = stack
-        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode)
-      _, _rest ->
-        error(original, skip)
-      <<_::bits>> ->
-        empty_error(original, skip)
-    end
-  end
-
-  @compile {:inline, object: 6}
-
-  defp object(rest, original, skip, stack, key_decode, string_decode) do
-    key(rest, original, skip, [[] | stack], key_decode, string_decode)
-  end
-
-  defp object(data, original, skip, stack, key_decode, string_decode, value) do
-    bytecase data do
-      _ in '\s\n\t\r', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode, value)
-      _ in '}', rest ->
-        skip = skip + 1
-        [key, acc | stack] = stack
-        final = [{key_decode.(key), value} | acc]
-        continue(rest, original, skip, stack, key_decode, string_decode, :maps.from_list(final))
-      _ in ',', rest ->
-        skip = skip + 1
-        [key, acc | stack] = stack
-        acc = [{key_decode.(key), value} | acc]
-        key(rest, original, skip, [acc | stack], key_decode, string_decode)
-      _, _rest ->
-        error(original, skip)
-      <<_::bits>> ->
-        empty_error(original, skip)
-    end
-  end
-
-  defp key(data, original, skip, stack, key_decode, string_decode) do
-    bytecase data do
-      _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode)
+        key(rest, original, skip + 1, stack, opts)
       _ in '}', rest ->
         case stack do
           [[] | stack] ->
-            continue(rest, original, skip + 1, stack, key_decode, string_decode, %{})
+            continue(rest, original, skip + 1, stack, opts, %{})
           _ ->
             error(original, skip)
         end
       _ in '"', rest ->
-        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, 0)
+        string(rest, original, skip + 1, [@key | stack], opts, 0)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -314,12 +353,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, opts, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        key(rest, original, skip + 1, stack, opts, value)
       _ in ':', rest ->
-        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@object, value | stack], opts)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -330,73 +369,77 @@ defmodule Jason.Decoder do
   # TODO: check if this approach would be faster:
   # https://git.ninenines.eu/cowlib.git/tree/src/cow_ws.erl#n469
   # http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
-  defp string(data, original, skip, stack, key_decode, string_decode, len) do
+  defp string(data, original, skip, stack, opts, len) do
     bytecase data, 128 do
       _ in '"', rest ->
+        string_decode = string_decode_function(opts)
         string = string_decode.(binary_part(original, skip, len))
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, opts, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, part)
+        escape(rest, original, skip + len, stack, opts, part)
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 1)
+        string(rest, original, skip, stack, opts, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 2)
+        string(rest, original, skip, stack, opts, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 3)
+        string(rest, original, skip, stack, opts, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 4)
+        string(rest, original, skip, stack, opts, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp string(data, original, skip, stack, key_decode, string_decode, acc, len) do
+  defp string(data, original, skip, stack, opts, acc, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         last = binary_part(original, skip, len)
         string = IO.iodata_to_binary([acc | last])
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, opts, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, [acc | part])
+        escape(rest, original, skip + len, stack, opts, [acc | part])
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 1)
+        string(rest, original, skip, stack, opts, acc, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 2)
+        string(rest, original, skip, stack, opts, acc, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 3)
+        string(rest, original, skip, stack, opts, acc, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 4)
+        string(rest, original, skip, stack, opts, acc, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp escape(data, original, skip, stack, key_decode, string_decode, acc) do
+  defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
+  defp string_decode_function(%{strings: :reference}), do: &(&1)
+
+  defp escape(data, original, skip, stack, opts, acc) do
     bytecase data do
       _ in 'b', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\b'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\b'], 0)
       _ in 't', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\t'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\t'], 0)
       _ in 'n', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\n'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\n'], 0)
       _ in 'f', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\f'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\f'], 0)
       _ in 'r', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\r'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\r'], 0)
       _ in '"', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\"'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\"'], 0)
       _ in '/', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '/'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '/'], 0)
       _ in '\\', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\\'], 0)
+        string(rest, original, skip + 2, stack, opts, [acc | '\\'], 0)
       _ in 'u', rest ->
-        escapeu(rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu(rest, original, skip, stack, opts, acc)
       _, _rest ->
         error(original, skip + 1)
       <<_::bits>> ->
@@ -432,8 +475,8 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, acc) do
-      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, opts, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, opts, acc)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -441,20 +484,20 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc) do
+    defp escapeu_first_clauses(last, rest, original, skip, stack, opts, acc) do
       for {int, first} <- unicode_escapes(),
           not (first in 0xDC..0xDF) do
-        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, opts, acc)
       end
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, opts, acc)
          when first in 0xD8..0xDB do
       hi =
         quote bind_quoted: [first: first, last: last] do
           0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, hi]
+      args = [rest, original, skip, stack, opts, acc, hi]
       [clause] =
         quote location: :keep do
           unquote(int) -> escape_surrogate(unquote_splicing(args))
@@ -462,7 +505,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, opts, acc)
          when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -477,7 +520,7 @@ defmodule Jason.Decoder do
             [acc, byte1, byte2]
           end
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, opts, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -485,7 +528,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, opts, acc)
          when first <= 0x07 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -495,7 +538,7 @@ defmodule Jason.Decoder do
           byte2 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, opts, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -503,7 +546,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, opts, acc)
          when first <= 0xFF do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -514,7 +557,7 @@ defmodule Jason.Decoder do
           byte3 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2, byte3]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, opts, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -541,9 +584,9 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, opts, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, opts, acc, hi)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -551,22 +594,22 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, opts, acc, hi) do
       digits1 = 'Dd'
       digits2 = Stream.concat([?C..?F, ?c..?f])
       for {int, first} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, opts, acc, hi)
       end
     end
 
-    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, opts, acc, hi) do
       skip = quote do: unquote(skip) + 12
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
           lo = ((first &&& 0x03) <<< 8) + last
           [acc | <<(hi + lo)::utf8>>]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, opts, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
@@ -576,12 +619,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, opts, acc) do
     require Unescape
     last = escapeu_last(int2, original, skip)
-    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, opts, acc)
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc) do
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _opts, _acc) do
     empty_error(original, skip)
   end
 
@@ -593,12 +636,13 @@ defmodule Jason.Decoder do
   end
 
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
-       skip, stack, key_decode, string_decode, acc, hi) do
+       skip, stack, opts, acc, hi) do
     require Unescape
     last = escapeu_last(int2, original, skip + 6)
-    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, opts, acc, hi)
   end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc, _hi) do
+
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _opts, _acc, _hi) do
     error(original, skip + 6)
   end
 
@@ -609,12 +653,16 @@ defmodule Jason.Decoder do
       token_error(token, skip)
   end
 
-  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode) do
+  defp error(<<_rest::bits>>, _original, skip, _stack, _opts) do
     throw {:position, skip - 1}
   end
 
   defp empty_error(_original, skip) do
     throw {:position, skip}
+  end
+
+  defp duplicate_key_error(key) do
+    throw {:duplicate_key, key}
   end
 
   @compile {:inline, error: 2, token_error: 2, token_error: 3}
@@ -630,28 +678,30 @@ defmodule Jason.Decoder do
     throw {:token, binary_part(token, position, len), position}
   end
 
-  @compile {:inline, continue: 7}
-  defp continue(rest, original, skip, stack, key_decode, string_decode, value) do
+  @compile {:inline, continue: 6}
+  defp continue(rest, original, skip, stack, opts, value) do
     case stack do
       [@terminate | stack] ->
-        terminate(rest, original, skip, stack, key_decode, string_decode, value)
+        terminate(rest, original, skip, stack, opts, value)
       [@array | stack] ->
-        array(rest, original, skip, stack, key_decode, string_decode, value)
+        array(rest, original, skip, stack, opts, value)
       [@key | stack] ->
-        key(rest, original, skip, stack, key_decode, string_decode, value)
+        key(rest, original, skip, stack, opts, value)
       [@object | stack] ->
-        object(rest, original, skip, stack, key_decode, string_decode, value)
+        object(rest, original, skip, stack, opts, value)
     end
   end
 
-  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, value)
+  defp terminate(<<byte, rest::bits>>, original, skip, stack, opts, value)
        when byte in '\s\n\r\t' do
-    terminate(rest, original, skip + 1, stack, key_decode, string_decode, value)
+    terminate(rest, original, skip + 1, stack, opts, value)
   end
-  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, value) do
+
+  defp terminate(<<>>, _original, _skip, _stack, _opts, value) do
     value
   end
-  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _value) do
+
+  defp terminate(<<_rest::bits>>, original, skip, _stack, _opts, _value) do
     error(original, skip)
   end
 end

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -14,7 +14,7 @@ defmodule Jason do
 
   @type strings :: :reference | :copy
 
-  @type decode_opt :: {:keys, keys} | {:strings, strings}
+  @type decode_opt :: {:keys, keys} | {:strings, strings} | {:maps, :strict}
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -35,6 +35,12 @@ defmodule Jason do
       * `:copy` - always copies the strings. This option is especially useful when parts of the
         decoded data will be stored for a long time (in ets or some process) to avoid keeping
         the reference to the original data.
+
+    * `:maps` - controls how json are decoded. Possible values are:
+
+      * `:strict` - checks the json for duplicate keys and raises
+        if they appear. For example `{"a": 1, "a": 2}` would be
+        rejected, since both keys would be decoded to the key `"a"`.
 
   ## Decoding keys to atoms
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -32,6 +32,7 @@ defmodule Jason.DecodeTest do
     assert parse!("-99.99e-99") == -99.99e-99
     assert parse!("123456789.123456789e123") == 123456789.123456789e123
   end
+
   test "strings" do
     assert_fail_with ~s("), "unexpected end of input at position 1"
     assert_fail_with ~s("\\"), "unexpected end of input at position 3"
@@ -83,6 +84,17 @@ defmodule Jason.DecodeTest do
     end
     key = String.to_atom(key)
     assert parse!(~s({"#{key}": "value"}), keys: :atoms) == %{key => "value"}
+  end
+
+  test "objects with strict option" do
+    assert parse!("{}", keys: :atoms, maps: :strict) == %{}
+    assert parse!("{}", keys: :atoms!, maps: :strict) == %{}
+    assert parse!(~s({"foo": "bar"}), keys: :atoms, maps: :strict) == %{foo: "bar"}
+    assert parse!(~s({"foo": "bar"}), keys: :atoms!, maps: :strict) == %{foo: "bar"}
+
+    assert_raise DecodeError, "duplicate key: a", fn ->
+      parse!(~s({"a": "1", "c": "3", "a": "3"}), maps: :strict)
+    end
   end
 
   test "copying strings on decode" do


### PR DESCRIPTION
#86 

I've refactor **Decode** module, because when I tried to add new opt is was very difficult because all functions add key_decode, string_decode and I would have to refactor all functions, now It's ease to add new options. 

I added strict option on decode because I need to know when my JSON has duplicated keys. 

```elixir
iex(3)> Jason.decode!(~s({"a": 1, "a": 2}), maps: :strict)
** (Jason.DecodeError) duplicate key: a
    (jason) lib/jason.ex:84: Jason.decode!/2
```