### PR TITLE
Use full name and short identifier from SPDX License List

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Protocol.derive(Jason.Encoder, NameOfTheStruct)
 
 ## License
 
-Jason is released under the Apache 2.0 License - see the [LICENSE](LICENSE) file.
+Jason is released under the Apache License 2.0 - see the [LICENSE](LICENSE) file.
 
 Some elements of tests and benchmarks have their origins in the
 [Poison library](https://github.com/devinus/poison) and were initially licensed under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Jason.Mixfile do
   defp package() do
     [
       maintainers: ["Michał Muskała"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/michalmuskala/jason"}
     ]
   end


### PR DESCRIPTION
https://spdx.org/licenses/Apache-2.0.html

From https://hex.pm/docs/publish

> It is recommended to use SPDX License identifier.