### PR TITLE
Adds float to decimal decoding option

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -43,8 +43,9 @@ defmodule Jason.Decoder do
   def parse(data, opts) when is_binary(data) do
     key_decode = key_decode_function(opts)
     string_decode = string_decode_function(opts)
+    float_decode = float_decode_function(opts)
     try do
-      value(data, data, 0, [@terminate], key_decode, string_decode)
+      value(data, data, 0, [@terminate], key_decode, string_decode, float_decode)
     catch
       {:position, position} ->
         {:error, %DecodeError{position: position, data: data}}
@@ -64,202 +65,205 @@ defmodule Jason.Decoder do
   defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
   defp string_decode_function(%{strings: :reference}), do: &(&1)
 
-  defp value(data, original, skip, stack, key_decode, string_decode) do
+  defp float_decode_function(%{floats: :decimals}), do: &Decimal.new/1
+  defp float_decode_function(%{floats: :native}), do: &:erlang.binary_to_float/1
+
+  defp value(data, original, skip, stack, key_decode, string_decode, float_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        value(rest, original, skip + 1, stack, key_decode, string_decode)
+        value(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       _ in '0', rest ->
-        number_zero(rest, original, skip, stack, key_decode, string_decode, 1)
+        number_zero(rest, original, skip, stack, key_decode, string_decode, float_decode, 1)
       _ in '123456789', rest ->
-        number(rest, original, skip, stack, key_decode, string_decode, 1)
+        number(rest, original, skip, stack, key_decode, string_decode, float_decode, 1)
       _ in '-', rest ->
-        number_minus(rest, original, skip, stack, key_decode, string_decode)
+        number_minus(rest, original, skip, stack, key_decode, string_decode, float_decode)
       _ in '"', rest ->
-        string(rest, original, skip + 1, stack, key_decode, string_decode, 0)
+        string(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, 0)
       _ in '[', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       _ in '{', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       _ in ']', rest ->
-        empty_array(rest, original, skip + 1, stack, key_decode, string_decode)
+        empty_array(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       _ in 't', rest ->
         case rest do
           <<"rue", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, true)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, float_decode, true)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'f', rest ->
         case rest do
           <<"alse", rest::bits>> ->
-            continue(rest, original, skip + 5, stack, key_decode, string_decode, false)
+            continue(rest, original, skip + 5, stack, key_decode, string_decode, float_decode, false)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'n', rest ->
         case rest do
           <<"ull", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, nil)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, float_decode, nil)
           <<_::bits>> ->
             error(original, skip)
         end
       _, rest ->
-        error(rest, original, skip + 1, stack, key_decode, string_decode)
+        error(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       <<_::bits>> ->
         error(original, skip)
     end
   end
 
-  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    number_zero(rest, original, skip, stack, key_decode, string_decode, 2)
+  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode) do
+    number_zero(rest, original, skip, stack, key_decode, string_decode, float_decode, 2)
   end
-  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode)
+  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode)
        when byte in '123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, 2)
+    number(rest, original, skip, stack, key_decode, string_decode, float_decode, 2)
   end
-  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode) do
+  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode) do
     error(original, skip + 1)
   end
 
-  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
+  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) when e in 'eE' do
     prefix = binary_part(original, skip, len)
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, prefix)
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, float_decode, prefix)
   end
-  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
     int = String.to_integer(binary_part(original, skip, len))
-    continue(rest, original, skip + len, stack, key_decode, string_decode, int)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, float_decode, int)
   end
 
-  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when e in 'eE' do
-    number_exp(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
     token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    float = try_parse_float(token, token, float_decode, skip)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, float_decode, float)
   end
 
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
     token = binary_part(original, skip, len)
-    float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    float = try_parse_float(token, token, float_decode, skip)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, float_decode, float)
   end
 
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, prefix)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, prefix, 1)
   end
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, prefix)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, float_decode, prefix, 1)
   end
-  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix) do
+  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, _prefix) do
     error(original, skip)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, prefix, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, _prefix, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, float_decode, prefix, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, prefix, len) do
     suffix = binary_part(original, skip, len)
     string = prefix <> ".0e" <> suffix
     prefix_size = byte_size(prefix)
     initial_skip = skip - prefix_size - 1
     final_skip = skip + len
     token = binary_part(original, initial_skip, prefix_size + len + 1)
-    float = try_parse_float(string, token, initial_skip)
-    continue(rest, original, final_skip, stack, key_decode, string_decode, float)
+    float = try_parse_float(string, token, float_decode, initial_skip)
+    continue(rest, original, final_skip, stack, key_decode, string_decode, float_decode, float)
   end
 
-  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
   end
-  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, "0")
+  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) when e in 'eE' do
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, float_decode, "0")
   end
-  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    continue(rest, original, skip + len, stack, key_decode, string_decode, 0)
-  end
-
-  @compile {:inline, array: 6}
-
-  defp array(rest, original, skip, stack, key_decode, string_decode) do
-    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode)
+  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, len) do
+    continue(rest, original, skip + len, stack, key_decode, string_decode, float_decode, 0)
   end
 
-  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode) do
+  @compile {:inline, array: 8}
+
+  defp array(rest, original, skip, stack, key_decode, string_decode, float_decode) do
+    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode, float_decode)
+  end
+
+  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode) do
     case stack do
       [@array, [] | stack] ->
-        continue(rest, original, skip, stack, key_decode, string_decode, [])
+        continue(rest, original, skip, stack, key_decode, string_decode, float_decode, [])
       _ ->
         error(original, skip - 1)
     end
   end
 
-  defp array(data, original, skip, stack, key_decode, string_decode, value) do
+  defp array(data, original, skip, stack, key_decode, string_decode, float_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, value)
       _ in ']', rest ->
         [acc | stack] = stack
         value = :lists.reverse(acc, [value])
-        continue(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        continue(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, value)
       _ in ',', rest ->
         [acc | stack] = stack
-        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode, float_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -267,26 +271,26 @@ defmodule Jason.Decoder do
     end
   end
 
-  @compile {:inline, object: 6}
+  @compile {:inline, object: 7}
 
-  defp object(rest, original, skip, stack, key_decode, string_decode) do
-    key(rest, original, skip, [[] | stack], key_decode, string_decode)
+  defp object(rest, original, skip, stack, key_decode, string_decode, float_decode) do
+    key(rest, original, skip, [[] | stack], key_decode, string_decode, float_decode)
   end
 
-  defp object(data, original, skip, stack, key_decode, string_decode, value) do
+  defp object(data, original, skip, stack, key_decode, string_decode, float_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, value)
       _ in '}', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         final = [{key_decode.(key), value} | acc]
-        continue(rest, original, skip, stack, key_decode, string_decode, :maps.from_list(final))
+        continue(rest, original, skip, stack, key_decode, string_decode, float_decode, :maps.from_list(final))
       _ in ',', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         acc = [{key_decode.(key), value} | acc]
-        key(rest, original, skip, [acc | stack], key_decode, string_decode)
+        key(rest, original, skip, [acc | stack], key_decode, string_decode, float_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -294,19 +298,19 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode) do
+  defp key(data, original, skip, stack, key_decode, string_decode, float_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, float_decode)
       _ in '}', rest ->
         case stack do
           [[] | stack] ->
-            continue(rest, original, skip + 1, stack, key_decode, string_decode, %{})
+            continue(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, %{})
           _ ->
             error(original, skip)
         end
       _ in '"', rest ->
-        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, 0)
+        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, float_decode, 0)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -314,12 +318,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, key_decode, string_decode, float_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, value)
       _ in ':', rest ->
-        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode, float_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -330,73 +334,73 @@ defmodule Jason.Decoder do
   # TODO: check if this approach would be faster:
   # https://git.ninenines.eu/cowlib.git/tree/src/cow_ws.erl#n469
   # http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
-  defp string(data, original, skip, stack, key_decode, string_decode, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, float_decode, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         string = string_decode.(binary_part(original, skip, len))
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, float_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, part)
+        escape(rest, original, skip + len, stack, key_decode, string_decode, float_decode, part)
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp string(data, original, skip, stack, key_decode, string_decode, acc, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, float_decode, acc, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         last = binary_part(original, skip, len)
         string = IO.iodata_to_binary([acc | last])
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, float_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, [acc | part])
+        escape(rest, original, skip + len, stack, key_decode, string_decode, float_decode, [acc | part])
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, acc, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, acc, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, acc, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, float_decode, acc, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp escape(data, original, skip, stack, key_decode, string_decode, acc) do
+  defp escape(data, original, skip, stack, key_decode, string_decode, float_decode, acc) do
     bytecase data do
       _ in 'b', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\b'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\b'], 0)
       _ in 't', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\t'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\t'], 0)
       _ in 'n', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\n'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\n'], 0)
       _ in 'f', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\f'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\f'], 0)
       _ in 'r', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\r'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\r'], 0)
       _ in '"', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\"'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\"'], 0)
       _ in '/', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '/'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '/'], 0)
       _ in '\\', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\\'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, float_decode, [acc | '\\'], 0)
       _ in 'u', rest ->
-        escapeu(rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu(rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
       _, _rest ->
         error(original, skip + 1)
       <<_::bits>> ->
@@ -432,8 +436,8 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, acc) do
-      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -441,20 +445,20 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc) do
+    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc) do
       for {int, first} <- unicode_escapes(),
           not (first in 0xDC..0xDF) do
-        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
       end
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
          when first in 0xD8..0xDB do
       hi =
         quote bind_quoted: [first: first, last: last] do
           0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, hi]
+      args = [rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi]
       [clause] =
         quote location: :keep do
           unquote(int) -> escape_surrogate(unquote_splicing(args))
@@ -462,7 +466,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
          when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -477,7 +481,7 @@ defmodule Jason.Decoder do
             [acc, byte1, byte2]
           end
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, float_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -485,7 +489,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
          when first <= 0x07 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -495,7 +499,7 @@ defmodule Jason.Decoder do
           byte2 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, float_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -503,7 +507,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
          when first <= 0xFF do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -514,7 +518,7 @@ defmodule Jason.Decoder do
           byte3 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2, byte3]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, float_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -541,9 +545,9 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -551,22 +555,22 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi) do
       digits1 = 'Dd'
       digits2 = Stream.concat([?C..?F, ?c..?f])
       for {int, first} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi)
       end
     end
 
-    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi) do
       skip = quote do: unquote(skip) + 12
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
           lo = ((first &&& 0x03) <<< 8) + last
           [acc | <<(hi + lo)::utf8>>]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, float_decode, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
@@ -576,12 +580,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, acc) do
     require Unescape
     last = escapeu_last(int2, original, skip)
-    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc)
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc) do
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, _acc) do
     empty_error(original, skip)
   end
 
@@ -593,23 +597,23 @@ defmodule Jason.Decoder do
   end
 
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
-       skip, stack, key_decode, string_decode, acc, hi) do
+       skip, stack, key_decode, string_decode, float_decode, acc, hi) do
     require Unescape
     last = escapeu_last(int2, original, skip + 6)
-    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, float_decode, acc, hi)
   end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc, _hi) do
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, _acc, _hi) do
     error(original, skip + 6)
   end
 
-  defp try_parse_float(string, token, skip) do
-    :erlang.binary_to_float(string)
+  defp try_parse_float(string, token, float_decode, skip) do
+    float_decode.(string)
   catch
     :error, :badarg ->
       token_error(token, skip)
   end
 
-  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode) do
+  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode, _float_decode) do
     throw {:position, skip - 1}
   end
 
@@ -630,28 +634,28 @@ defmodule Jason.Decoder do
     throw {:token, binary_part(token, position, len), position}
   end
 
-  @compile {:inline, continue: 7}
-  defp continue(rest, original, skip, stack, key_decode, string_decode, value) do
+  @compile {:inline, continue: 8}
+  defp continue(rest, original, skip, stack, key_decode, string_decode, float_decode, value) do
     case stack do
       [@terminate | stack] ->
-        terminate(rest, original, skip, stack, key_decode, string_decode, value)
+        terminate(rest, original, skip, stack, key_decode, string_decode, float_decode, value)
       [@array | stack] ->
-        array(rest, original, skip, stack, key_decode, string_decode, value)
+        array(rest, original, skip, stack, key_decode, string_decode, float_decode, value)
       [@key | stack] ->
-        key(rest, original, skip, stack, key_decode, string_decode, value)
+        key(rest, original, skip, stack, key_decode, string_decode, float_decode, value)
       [@object | stack] ->
-        object(rest, original, skip, stack, key_decode, string_decode, value)
+        object(rest, original, skip, stack, key_decode, string_decode, float_decode, value)
     end
   end
 
-  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, value)
+  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, float_decode, value)
        when byte in '\s\n\r\t' do
-    terminate(rest, original, skip + 1, stack, key_decode, string_decode, value)
+    terminate(rest, original, skip + 1, stack, key_decode, string_decode, float_decode, value)
   end
-  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, value) do
+  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, _float_decode, value) do
     value
   end
-  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _value) do
+  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _float_decode, _value) do
     error(original, skip)
   end
 end

--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -66,7 +66,14 @@ defmodule Jason.Decoder do
   defp string_decode_function(%{strings: :reference}), do: &(&1)
 
   defp float_decode_function(%{floats: :decimals}) do
-    fn string, _error_fun -> Decimal.new(string) end
+    fn string, token, skip ->
+      try do
+        Decimal.new(string)
+      catch
+        Decimal.Error ->
+          token_error(token, skip)
+      end
+    end
   end
 
   defp float_decode_function(%{floats: :native}) do

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -38,6 +38,11 @@ defmodule Jason do
         decoded data will be stored for a long time (in ets or some process) to avoid keeping
         the reference to the original data.
 
+    * `:floats` - controls how floats are decoded. Possible values are:
+
+      * `:native` (default) - Native conversion from binary to float using `:erlang.binary_to_float/1`,
+      * `:decimals` - uses `Decimal.new/1` to parse the binary into a Decimal struct with arbitrary precision.
+
   ## Decoding keys to atoms
 
   The `:atoms` option uses the `String.to_atom/1` call that can create atoms at runtime.

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -14,7 +14,9 @@ defmodule Jason do
 
   @type strings :: :reference | :copy
 
-  @type decode_opt :: {:keys, keys} | {:strings, strings}
+  @type floats :: :native | :decimals
+
+  @type decode_opt :: {:keys, keys} | {:strings, strings} | {:floats, floats}
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -223,6 +225,6 @@ defmodule Jason do
   end
 
   defp format_decode_opts(opts) do
-    Enum.into(opts, %{keys: :strings, strings: :reference})
+    Enum.into(opts, %{keys: :strings, strings: :reference, floats: :native})
   end
 end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -110,6 +110,18 @@ defmodule Jason.DecodeTest do
     assert parse!(~s({"FOO": "bar"}), keys: &String.downcase/1) == %{"foo" => "bar"}
   end
 
+  test "parsing floats to decimals" do
+    assert parse!("0.1", floats: :decimals) == Decimal.new("0.1")
+    assert parse!("-0.1", floats: :decimals) == Decimal.new("-0.1")
+    assert parse!("1.0e0", floats: :decimals) == Decimal.new("1.0e0")
+    assert parse!("1.0e+0", floats: :decimals) == Decimal.new("1.0e+0")
+    assert parse!("0.1e1", floats: :decimals) == Decimal.new("0.1e1")
+    assert parse!("0.1e-1", floats: :decimals) == Decimal.new("0.1e-1")
+
+    assert parse!("123456789.123456789e123", floats: :decimals) ==
+             Decimal.new("123456789.123456789e123")
+  end
+
   test "arrays" do
     assert_fail_with "[", "unexpected end of input at position 1"
     assert_fail_with "[,", "unexpected byte at position 1: 0x2C (',')"


### PR DESCRIPTION
Floats in elixir/erlang are notoriously known for being prone to
precision errors, which can be dangerous when dealing with currencies,
money, etc.

All issues that [Decimal](https://github.com/ericmj/decimal) aims to mitigate.

This commit adds the option for floats to be immediately converted to
Decimals without going through float conversion.

The approach was heavily inspired on the decoding options for
strings and keys.

### TODO:
- [x] Update documentation