### PR TITLE
At least please include a "List of Most Common custom Jason.Encoder" for people can share it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ erl_crash.dump
 # Ignore benchmark specific dependencies etc (separate project to work around problems with dependencies)
 /bench/_build
 /bench/deps
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Protocol.derive(Jason.Encoder, NameOfTheStruct)
 
 Feel you free of share with the community your encode implement of the most common library that you use it. It´s can be very useful for the community. ;) 谢谢
 
-# BSON.ObjectId of :mongodb 
+### BSON.ObjectId of :mongodb 
 
 ```elixir
 defimpl Jason.Encoder, for: BSON.ObjectId do

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ Protocol.derive(Jason.Encoder, NameOfTheStruct, only: [...])
 Protocol.derive(Jason.Encoder, NameOfTheStruct)
 ```
 
+## List of Most Common custom Jason.Encoder 
+
+Feel you free of share with the community your encode implement of the most common library that you use it. It´s can be very useful for the community. ;) 谢谢
+
+# BSON.ObjectId of :mongodb 
+
+```elixir
+defimpl Jason.Encoder, for: BSON.ObjectId do
+  ## Defimpl Encode for {:mongodb, "~> 0.5.1"}
+  def encode(bson_id,_args) do
+    id_string_format = BSON.ObjectId.encode!(bson_id)
+    id_string_with_json_format = "\"#{id_string_format}\""
+
+    id_string_with_json_format
+  end
+end
+```
+
 ## License
 
 Jason is released under the Apache License 2.0 - see the [LICENSE](LICENSE) file.

--- a/lib/encoders/mongo/impl_bson_objectid.ex
+++ b/lib/encoders/mongo/impl_bson_objectid.ex
@@ -1,0 +1,9 @@
+defimpl Jason.Encoder, for: BSON.ObjectId do
+  ## Defimpl Encode for {:mongodb, "~> 0.5.1"}
+  def encode(bson_id,_args) do
+    id_string_format = BSON.ObjectId.encode!(bson_id)
+    id_string_with_json_format = "\"#{id_string_format}\""
+
+    id_string_with_json_format
+  end
+end


### PR DESCRIPTION
I have include a simple defimpl for BSON.ObjectId of :mongodb library with the target of encode the json. Now, phoenix is using Jason by default then when people include mongodb, and try cast to Json, by default will found an error. "Jason.Encoder not implemented for #BSON.ObjectId<....>" I would like avoid this error.

I think that you prefer don´t add in Jason the implementations of protocol, I respect your decision, but I would like that you consider or think at least include a List of Most Common custom Jason.Encoder, for the people can share more easy. Only add in docs can improve the productivity.

Sorry all and Thanks,
