### PR TITLE
Add an option to decode JSON objects as lists

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -43,8 +43,9 @@ defmodule Jason.Decoder do
   def parse(data, opts) when is_binary(data) do
     key_decode = key_decode_function(opts)
     string_decode = string_decode_function(opts)
+    object_decode = object_decode_function(opts)
     try do
-      value(data, data, 0, [@terminate], key_decode, string_decode)
+      value(data, data, 0, [@terminate], key_decode, string_decode, object_decode)
     catch
       {:position, position} ->
         {:error, %DecodeError{position: position, data: data}}
@@ -64,156 +65,159 @@ defmodule Jason.Decoder do
   defp string_decode_function(%{strings: :copy}), do: &:binary.copy/1
   defp string_decode_function(%{strings: :reference}), do: &(&1)
 
-  defp value(data, original, skip, stack, key_decode, string_decode) do
+  defp object_decode_function(%{objects: :maps}), do: &:maps.from_list/1
+  defp object_decode_function(%{objects: :preserve_order}), do: &Jason.OrderedObject.new(:lists.reverse(&1))
+
+  defp value(data, original, skip, stack, key_decode, string_decode, object_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        value(rest, original, skip + 1, stack, key_decode, string_decode)
+        value(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       _ in '0', rest ->
-        number_zero(rest, original, skip, stack, key_decode, string_decode, 1)
+        number_zero(rest, original, skip, stack, key_decode, string_decode, object_decode, 1)
       _ in '123456789', rest ->
-        number(rest, original, skip, stack, key_decode, string_decode, 1)
+        number(rest, original, skip, stack, key_decode, string_decode, object_decode, 1)
       _ in '-', rest ->
-        number_minus(rest, original, skip, stack, key_decode, string_decode)
+        number_minus(rest, original, skip, stack, key_decode, string_decode, object_decode)
       _ in '"', rest ->
-        string(rest, original, skip + 1, stack, key_decode, string_decode, 0)
+        string(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, 0)
       _ in '[', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       _ in '{', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       _ in ']', rest ->
-        empty_array(rest, original, skip + 1, stack, key_decode, string_decode)
+        empty_array(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       _ in 't', rest ->
         case rest do
           <<"rue", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, true)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, object_decode, true)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'f', rest ->
         case rest do
           <<"alse", rest::bits>> ->
-            continue(rest, original, skip + 5, stack, key_decode, string_decode, false)
+            continue(rest, original, skip + 5, stack, key_decode, string_decode, object_decode, false)
           <<_::bits>> ->
             error(original, skip)
         end
       _ in 'n', rest ->
         case rest do
           <<"ull", rest::bits>> ->
-            continue(rest, original, skip + 4, stack, key_decode, string_decode, nil)
+            continue(rest, original, skip + 4, stack, key_decode, string_decode, object_decode, nil)
           <<_::bits>> ->
             error(original, skip)
         end
       _, rest ->
-        error(rest, original, skip + 1, stack, key_decode, string_decode)
+        error(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       <<_::bits>> ->
         error(original, skip)
     end
   end
 
-  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode) do
-    number_zero(rest, original, skip, stack, key_decode, string_decode, 2)
+  defp number_minus(<<?0, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode) do
+    number_zero(rest, original, skip, stack, key_decode, string_decode, object_decode, 2)
   end
-  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode)
+  defp number_minus(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode)
        when byte in '123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, 2)
+    number(rest, original, skip, stack, key_decode, string_decode, object_decode, 2)
   end
-  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode) do
+  defp number_minus(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode) do
     error(original, skip + 1)
   end
 
-  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
+  defp number(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) when e in 'eE' do
     prefix = binary_part(original, skip, len)
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, prefix)
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, object_decode, prefix)
   end
-  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
     int = String.to_integer(binary_part(original, skip, len))
-    continue(rest, original, skip + len, stack, key_decode, string_decode, int)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, object_decode, int)
   end
 
-  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_frac(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_frac_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_frac_cont(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when e in 'eE' do
-    number_exp(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_frac_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
     token = binary_part(original, skip, len)
     float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, object_decode, float)
   end
 
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
     token = binary_part(original, skip, len)
     float = try_parse_float(token, token, skip)
-    continue(rest, original, skip + len, stack, key_decode, string_decode, float)
+    continue(rest, original, skip + len, stack, key_decode, string_decode, object_decode, float)
   end
 
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, prefix)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, prefix, 1)
   end
-  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix)
+  defp number_exp_copy(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, prefix)
        when byte in '+-' do
-    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, prefix, 1)
+    number_exp_sign(rest, original, skip, stack, key_decode, string_decode, object_decode, prefix, 1)
   end
-  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix) do
+  defp number_exp_copy(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, _prefix) do
     error(original, skip)
   end
 
-  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_sign(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, prefix, len + 1)
   end
-  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _prefix, len) do
+  defp number_exp_sign(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, _prefix, len) do
     error(original, skip + len)
   end
 
-  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len)
+  defp number_exp_cont(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, prefix, len)
        when byte in '0123456789' do
-    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, prefix, len + 1)
+    number_exp_cont(rest, original, skip, stack, key_decode, string_decode, object_decode, prefix, len + 1)
   end
-  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, prefix, len) do
+  defp number_exp_cont(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, prefix, len) do
     suffix = binary_part(original, skip, len)
     string = prefix <> ".0e" <> suffix
     prefix_size = byte_size(prefix)
@@ -221,45 +225,45 @@ defmodule Jason.Decoder do
     final_skip = skip + len
     token = binary_part(original, initial_skip, prefix_size + len + 1)
     float = try_parse_float(string, token, initial_skip)
-    continue(rest, original, final_skip, stack, key_decode, string_decode, float)
+    continue(rest, original, final_skip, stack, key_decode, string_decode, object_decode, float)
   end
 
-  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    number_frac(rest, original, skip, stack, key_decode, string_decode, len + 1)
+  defp number_zero(<<?., rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
+    number_frac(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
   end
-  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, len) when e in 'eE' do
-    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, "0")
+  defp number_zero(<<e, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) when e in 'eE' do
+    number_exp_copy(rest, original, skip + len + 1, stack, key_decode, string_decode, object_decode, "0")
   end
-  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, len) do
-    continue(rest, original, skip + len, stack, key_decode, string_decode, 0)
-  end
-
-  @compile {:inline, array: 6}
-
-  defp array(rest, original, skip, stack, key_decode, string_decode) do
-    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode)
+  defp number_zero(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, len) do
+    continue(rest, original, skip + len, stack, key_decode, string_decode, object_decode, 0)
   end
 
-  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode) do
+  @compile {:inline, array: 7}
+
+  defp array(rest, original, skip, stack, key_decode, string_decode, object_decode) do
+    value(rest, original, skip, [@array, [] | stack], key_decode, string_decode, object_decode)
+  end
+
+  defp empty_array(<<rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode) do
     case stack do
       [@array, [] | stack] ->
-        continue(rest, original, skip, stack, key_decode, string_decode, [])
+        continue(rest, original, skip, stack, key_decode, string_decode, object_decode, [])
       _ ->
         error(original, skip - 1)
     end
   end
 
-  defp array(data, original, skip, stack, key_decode, string_decode, value) do
+  defp array(data, original, skip, stack, key_decode, string_decode, object_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        array(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        array(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, value)
       _ in ']', rest ->
         [acc | stack] = stack
         value = :lists.reverse(acc, [value])
-        continue(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        continue(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, value)
       _ in ',', rest ->
         [acc | stack] = stack
-        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@array, [value | acc] | stack], key_decode, string_decode, object_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -267,26 +271,26 @@ defmodule Jason.Decoder do
     end
   end
 
-  @compile {:inline, object: 6}
+  @compile {:inline, object: 7}
 
-  defp object(rest, original, skip, stack, key_decode, string_decode) do
-    key(rest, original, skip, [[] | stack], key_decode, string_decode)
+  defp object(rest, original, skip, stack, key_decode, string_decode, object_decode) do
+    key(rest, original, skip, [[] | stack], key_decode, string_decode, object_decode)
   end
 
-  defp object(data, original, skip, stack, key_decode, string_decode, value) do
+  defp object(data, original, skip, stack, key_decode, string_decode, object_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        object(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        object(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, value)
       _ in '}', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
-        final = [{key_decode.(key), value} | acc]
-        continue(rest, original, skip, stack, key_decode, string_decode, :maps.from_list(final))
+        final = object_decode.([{key_decode.(key), value} | acc])
+        continue(rest, original, skip, stack, key_decode, string_decode, object_decode, final)
       _ in ',', rest ->
         skip = skip + 1
         [key, acc | stack] = stack
         acc = [{key_decode.(key), value} | acc]
-        key(rest, original, skip, [acc | stack], key_decode, string_decode)
+        key(rest, original, skip, [acc | stack], key_decode, string_decode, object_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -294,19 +298,19 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode) do
+  defp key(data, original, skip, stack, key_decode, string_decode, object_decode) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, object_decode)
       _ in '}', rest ->
         case stack do
           [[] | stack] ->
-            continue(rest, original, skip + 1, stack, key_decode, string_decode, %{})
+            continue(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, object_decode.([]))
           _ ->
             error(original, skip)
         end
       _ in '"', rest ->
-        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, 0)
+        string(rest, original, skip + 1, [@key | stack], key_decode, string_decode, object_decode, 0)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -314,12 +318,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp key(data, original, skip, stack, key_decode, string_decode, value) do
+  defp key(data, original, skip, stack, key_decode, string_decode, object_decode, value) do
     bytecase data do
       _ in '\s\n\t\r', rest ->
-        key(rest, original, skip + 1, stack, key_decode, string_decode, value)
+        key(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, value)
       _ in ':', rest ->
-        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode)
+        value(rest, original, skip + 1, [@object, value | stack], key_decode, string_decode, object_decode)
       _, _rest ->
         error(original, skip)
       <<_::bits>> ->
@@ -330,73 +334,73 @@ defmodule Jason.Decoder do
   # TODO: check if this approach would be faster:
   # https://git.ninenines.eu/cowlib.git/tree/src/cow_ws.erl#n469
   # http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
-  defp string(data, original, skip, stack, key_decode, string_decode, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, object_decode, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         string = string_decode.(binary_part(original, skip, len))
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, object_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, part)
+        escape(rest, original, skip + len, stack, key_decode, string_decode, object_decode, part)
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip + len)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp string(data, original, skip, stack, key_decode, string_decode, acc, len) do
+  defp string(data, original, skip, stack, key_decode, string_decode, object_decode, acc, len) do
     bytecase data, 128 do
       _ in '"', rest ->
         last = binary_part(original, skip, len)
         string = IO.iodata_to_binary([acc | last])
-        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, string)
+        continue(rest, original, skip + len + 1, stack, key_decode, string_decode, object_decode, string)
       _ in '\\', rest ->
         part = binary_part(original, skip, len)
-        escape(rest, original, skip + len, stack, key_decode, string_decode, [acc | part])
+        escape(rest, original, skip + len, stack, key_decode, string_decode, object_decode, [acc | part])
       _ in unquote(0x00..0x1F), _rest ->
         error(original, skip + len)
       _, rest ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 1)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, acc, len + 1)
       <<char::utf8, rest::bits>> when char <= 0x7FF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 2)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, acc, len + 2)
       <<char::utf8, rest::bits>> when char <= 0xFFFF ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 3)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, acc, len + 3)
       <<_char::utf8, rest::bits>> ->
-        string(rest, original, skip, stack, key_decode, string_decode, acc, len + 4)
+        string(rest, original, skip, stack, key_decode, string_decode, object_decode, acc, len + 4)
       <<_::bits>> ->
         empty_error(original, skip + len)
     end
   end
 
-  defp escape(data, original, skip, stack, key_decode, string_decode, acc) do
+  defp escape(data, original, skip, stack, key_decode, string_decode, object_decode, acc) do
     bytecase data do
       _ in 'b', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\b'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\b'], 0)
       _ in 't', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\t'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\t'], 0)
       _ in 'n', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\n'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\n'], 0)
       _ in 'f', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\f'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\f'], 0)
       _ in 'r', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\r'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\r'], 0)
       _ in '"', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\"'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\"'], 0)
       _ in '/', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '/'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '/'], 0)
       _ in '\\', rest ->
-        string(rest, original, skip + 2, stack, key_decode, string_decode, [acc | '\\'], 0)
+        string(rest, original, skip + 2, stack, key_decode, string_decode, object_decode, [acc | '\\'], 0)
       _ in 'u', rest ->
-        escapeu(rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu(rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
       _, _rest ->
         error(original, skip + 1)
       <<_::bits>> ->
@@ -432,8 +436,8 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, acc) do
-      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -441,20 +445,20 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc) do
+    defp escapeu_first_clauses(last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc) do
       for {int, first} <- unicode_escapes(),
           not (first in 0xDC..0xDF) do
-        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
       end
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
          when first in 0xD8..0xDB do
       hi =
         quote bind_quoted: [first: first, last: last] do
           0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, hi]
+      args = [rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi]
       [clause] =
         quote location: :keep do
           unquote(int) -> escape_surrogate(unquote_splicing(args))
@@ -462,7 +466,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
          when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -477,7 +481,7 @@ defmodule Jason.Decoder do
             [acc, byte1, byte2]
           end
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, object_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -485,7 +489,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
          when first <= 0x07 do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -495,7 +499,7 @@ defmodule Jason.Decoder do
           byte2 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, object_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -503,7 +507,7 @@ defmodule Jason.Decoder do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
          when first <= 0xFF do
       skip = quote do: (unquote(skip) + 6)
       acc =
@@ -514,7 +518,7 @@ defmodule Jason.Decoder do
           byte3 = (0b10 <<< 6) + (last &&& 0b111111)
           [acc, byte1, byte2, byte3]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, object_decode, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
@@ -541,9 +545,9 @@ defmodule Jason.Decoder do
       end
     end
 
-    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi)
       quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -551,22 +555,22 @@ defmodule Jason.Decoder do
       end
     end
 
-    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi) do
       digits1 = 'Dd'
       digits2 = Stream.concat([?C..?F, ?c..?f])
       for {int, first} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi)
       end
     end
 
-    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, acc, hi) do
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi) do
       skip = quote do: unquote(skip) + 12
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
           lo = ((first &&& 0x03) <<< 8) + last
           [acc | <<(hi + lo)::utf8>>]
         end
-      args = [rest, original, skip, stack, key_decode, string_decode, acc, 0]
+      args = [rest, original, skip, stack, key_decode, string_decode, object_decode, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
@@ -576,12 +580,12 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, acc) do
     require Unescape
     last = escapeu_last(int2, original, skip)
-    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, acc)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc)
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc) do
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, _acc) do
     empty_error(original, skip)
   end
 
@@ -593,12 +597,12 @@ defmodule Jason.Decoder do
   end
 
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
-       skip, stack, key_decode, string_decode, acc, hi) do
+       skip, stack, key_decode, string_decode, object_decode, acc, hi) do
     require Unescape
     last = escapeu_last(int2, original, skip + 6)
-    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, acc, hi)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, key_decode, string_decode, object_decode, acc, hi)
   end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _acc, _hi) do
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, _acc, _hi) do
     error(original, skip + 6)
   end
 
@@ -609,7 +613,7 @@ defmodule Jason.Decoder do
       token_error(token, skip)
   end
 
-  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode) do
+  defp error(<<_rest::bits>>, _original, skip, _stack, _key_decode, _string_decode, _object_decode) do
     throw {:position, skip - 1}
   end
 
@@ -630,28 +634,28 @@ defmodule Jason.Decoder do
     throw {:token, binary_part(token, position, len), position}
   end
 
-  @compile {:inline, continue: 7}
-  defp continue(rest, original, skip, stack, key_decode, string_decode, value) do
+  @compile {:inline, continue: 8}
+  defp continue(rest, original, skip, stack, key_decode, string_decode, object_decode, value) do
     case stack do
       [@terminate | stack] ->
-        terminate(rest, original, skip, stack, key_decode, string_decode, value)
+        terminate(rest, original, skip, stack, key_decode, string_decode, object_decode, value)
       [@array | stack] ->
-        array(rest, original, skip, stack, key_decode, string_decode, value)
+        array(rest, original, skip, stack, key_decode, string_decode, object_decode, value)
       [@key | stack] ->
-        key(rest, original, skip, stack, key_decode, string_decode, value)
+        key(rest, original, skip, stack, key_decode, string_decode, object_decode, value)
       [@object | stack] ->
-        object(rest, original, skip, stack, key_decode, string_decode, value)
+        object(rest, original, skip, stack, key_decode, string_decode, object_decode, value)
     end
   end
 
-  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, value)
+  defp terminate(<<byte, rest::bits>>, original, skip, stack, key_decode, string_decode, object_decode, value)
        when byte in '\s\n\r\t' do
-    terminate(rest, original, skip + 1, stack, key_decode, string_decode, value)
+    terminate(rest, original, skip + 1, stack, key_decode, string_decode, object_decode, value)
   end
-  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, value) do
+  defp terminate(<<>>, _original, _skip, _stack, _key_decode, _string_decode, _object_decode, value) do
     value
   end
-  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _value) do
+  defp terminate(<<_rest::bits>>, original, skip, _stack, _key_decode, _string_decode, _object_decode, _value) do
     error(original, skip)
   end
 end

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -14,7 +14,9 @@ defmodule Jason do
 
   @type strings :: :reference | :copy
 
-  @type decode_opt :: {:keys, keys} | {:strings, strings}
+  @type objects :: :maps | :preserve_order
+
+  @type decode_opt :: {:keys, keys} | {:strings, strings} | {:objects, objects}
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -35,6 +37,12 @@ defmodule Jason do
       * `:copy` - always copies the strings. This option is especially useful when parts of the
         decoded data will be stored for a long time (in ets or some process) to avoid keeping
         the reference to the original data.
+
+    * `:objects` - controls how objects are decoded. Possible values are:
+      * `:maps` (default) - objects are decoded as maps
+      * `:preserve_order` - objects are decoded into `Jason.OrderedObject` structs that preserve
+        the order of the keys in the original object. `Jason.OrderedObject` implements the `Access`
+        behaviour and the `Enumerable` protocol.
 
   ## Decoding keys to atoms
 
@@ -223,6 +231,6 @@ defmodule Jason do
   end
 
   defp format_decode_opts(opts) do
-    Enum.into(opts, %{keys: :strings, strings: :reference})
+    Enum.into(opts, %{keys: :strings, strings: :reference, objects: :maps})
   end
 end

--- a/lib/ordered_object.ex
+++ b/lib/ordered_object.ex
@@ -1,0 +1,56 @@
+defmodule Jason.OrderedObject do
+  @behaviour Access
+
+  defstruct map: %{}, ordered_keys: []
+
+  def new(values) do
+    {ordered_keys, _} = Enum.unzip(values)
+    map = :maps.from_list(values)
+    %__MODULE__{map: map, ordered_keys: ordered_keys}
+  end
+
+  @impl Access
+  def fetch(%__MODULE__{map: map}, key) do
+    Map.fetch(map, key)
+  end
+
+  @impl Access
+  def get_and_update(%__MODULE__{map: map} = obj, key, function) do
+    {value, new_data} = Map.get_and_update(map, key, function)
+    {value, %{obj | map: new_data}}
+  end
+
+  @impl Access
+  def pop(%__MODULE__{map: map, ordered_keys: ordered_keys}, key) do
+    {value, new_data} = Map.pop(map, key)
+
+    {value,
+     %__MODULE__{
+       map: new_data,
+       ordered_keys: List.delete(ordered_keys, key)
+     }}
+  end
+end
+
+defimpl Enumerable, for: Jason.OrderedObject do
+  def count(%{map: map}), do: Enumerable.Map.count(map)
+
+  def member?(%{map: map}, value), do: Enumerable.Map.member?(map, value)
+
+  def slice(%{map: map}), do: Enumerable.Map.slice(map)
+
+  def reduce(obj, acc, fun) do
+    Enumerable.List.reduce(as_pair_list(obj), acc, fun)
+  end
+
+  defp as_pair_list(%{map: map, ordered_keys: ordered_keys}) do
+    Enum.map(ordered_keys, fn key -> {key, map[key]} end)
+  end
+end
+
+defimpl Jason.Encoder, for: Jason.OrderedObject do
+  def encode(obj, opts) do
+    Enum.into(obj, [])
+    |> Jason.Encode.keyword(opts)
+  end
+end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -111,6 +111,23 @@ defmodule Jason.DecodeTest do
     assert parse!(~s({"FOO": "bar"}), keys: &String.downcase/1) == %{"foo" => "bar"}
   end
 
+  test "decoding objects preserving order" do
+    import Jason.OrderedObject, only: [new: 1]
+
+    assert parse!("{}", objects: :preserve_order) == new([])
+    assert parse!(~s({"foo": "bar"}), objects: :preserve_order) == new([{"foo", "bar"}])
+
+    expected = new([{"foo", "bar"}, {"baz", "quux"}])
+    assert parse!(~s({"foo": "bar", "baz": "quux"}), objects: :preserve_order) == expected
+
+    expected = new([{"foo", new([{"bar", "baz"}])}])
+    assert parse!(~s({"foo": {"bar": "baz"}}), objects: :preserve_order) == expected
+
+    # Combining with `keys: :atoms`
+    assert parse!(~s({"foo": "bar"}), keys: :atoms, objects: :preserve_order) == new([foo: "bar"])
+    assert parse!(~s({"foo": "bar"}), keys: :atoms!, objects: :preserve_order) == new([foo: "bar"])
+  end
+
   test "arrays" do
     assert_fail_with "[", ~S|unexpected end of input at position 1|
     assert_fail_with "[,", ~S|unexpected byte at position 1: 0x2C (",")|

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -98,6 +98,27 @@ defmodule Jason.EncoderTest do
     assert to_json(decimal) == ~s("1.0")
   end
 
+  test "OrderedObject" do
+    import Jason.OrderedObject, only: [new: 1]
+
+    assert to_json(new([])) == "{}"
+    assert to_json(new([{"foo", "bar"}]))  == ~s({"foo":"bar"})
+    assert to_json(new([foo: :bar])) == ~s({"foo":"bar"})
+    assert to_json(new([{42, :bar}])) == ~s({"42":"bar"})
+    assert to_json(new([{'foo', :bar}])) == ~s({"foo":"bar"})
+
+    multi_key_obj = new([{"foo", "foo1"}, {:foo, "foo2"}])
+    assert_raise EncodeError, "duplicate key: foo", fn ->
+      to_json(multi_key_obj, maps: :strict)
+    end
+
+    assert to_json(multi_key_obj) == ~s({"foo":"foo1","foo":"foo2"})
+
+    # Order is preserved when encoding
+    multi_key_obj = new(foo: 1, bar: 2, quux: 42)
+    assert to_json(multi_key_obj) == ~s({"foo":1,"bar":2,"quux":42})
+  end
+
   defmodule Derived do
     @derive Encoder
     defstruct name: ""

--- a/test/ordered_object_test.exs
+++ b/test/ordered_object_test.exs
@@ -1,0 +1,32 @@
+defmodule Jason.OrderedObjectTest do
+  use ExUnit.Case, async: true
+
+  alias Jason.OrderedObject
+
+  test "Access behavior" do
+    obj = OrderedObject.new([{:foo, 1}, {"bar", 2}])
+
+    assert obj[:foo] == 1
+    assert obj["bar"] == 2
+
+    assert Access.pop(obj, :foo) == {1, OrderedObject.new([{"bar", 2}])}
+
+    obj = OrderedObject.new(
+      foo: OrderedObject.new(bar: 1),
+    )
+    assert obj[:foo][:bar] == 1
+    modified_obj = put_in(obj[:foo][:bar], 2)
+    assert %OrderedObject{} = modified_obj[:foo]
+    assert modified_obj[:foo][:bar] == 2
+  end
+
+  test "Enumerable protocol" do
+    obj = OrderedObject.new(foo: 1, bar: 2, quux: 42)
+
+    assert Enum.count(obj) == 3
+    assert Enum.member?(obj, {:foo, 1})
+
+    assert Enum.into(obj, %{}) == %{foo: 1, bar: 2, quux: 42}
+    assert Enum.into(obj, []) == [foo: 1, bar: 2, quux: 42]
+  end
+end


### PR DESCRIPTION
This lets the user get the fields of a JSON object in the same order as they appear in the input, which can be useful for certain use cases.

The change is smaller than what the noisy diff suggests, but the way it's implemented I had to add the new decoding function to all affected function signatures. Maybe a refactor to have all the decoding functions (`key_decode`, `string_decode`, `object_decode`) would help here?

Essentially, this just adds an `:objects` option to `Jason.decode`, based on which either the default (and original) `:maps.from_list` is used, or the object is retained as a list of pairs (tuples), reversed so that it's in the same order as the input.

Let me know if this feature is useful!