### PR TITLE
Add a "Encoders" sub-section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Jason has a couple feature differences compared to Poison.
     of the `Jason.Encoder` protocol is always required.
   * different pretty-printing customisation options (default `pretty: true` works the same)
 
+### Encoders
+
 If you require encoders for any of the unsupported collection types, I suggest
 adding the needed implementations directly to your project:
 


### PR DESCRIPTION
💅 Just to able to the encoders documentation directly.

https://github.com/prodis/jason/tree/readme_nail_care#encoders