### PR TITLE
Update README for version 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:jason, "~> 1.3"}]
+  [{:jason, "~> 1.4"}]
 end
 ```
 


### PR DESCRIPTION
Update example hex dependency entry in `README.md` for version 1.4. 

This is a follow-up to the release of #155 as version 1.4.0 (6a966cc4a41927804e51ee94a08826e519402c57).