### PR TITLE
Optimize decode on small payloads

### DIFF
--- a/bench/data/small.json
+++ b/bench/data/small.json
@@ -1,0 +1,1 @@
+{"first_name": "John", "last_name": "Doe", "age": 25}

--- a/bench/decode.exs
+++ b/bench/decode.exs
@@ -20,6 +20,7 @@ decode_inputs = [
   "UTF-8 escaped",
   "UTF-8 unescaped",
   "Issue 90",
+  "Small",
 ]
 
 read_data = fn (name) ->


### PR DESCRIPTION
Hi,

I might have found a small optimization for decoding small payloads: by avoiding creating lambdas and just use pattern-matching where needed, we do slightly less work and use slightly less memory. Hopefully this can benefit tight loops with a lot of decoding calls like [this example](https://elixirforum.com/t/elixir-vs-python-performance-benchmarking/54260). This has no impact on bigger benches, so I added a new one.

See [bench](https://github.com/michalmuskala/jason/compare/master...sabiwara:faster-decode-small-bench?expand=1#diff-c5da301a3b1bb69eac8dd9ae227f7a232de0d9300c08d6134ff68d8af640e837R53-R61):

```
Comparison: 
Jason 2        1.24 M
Jason          1.12 M - 1.11x slower +85.08 ns

Memory usage statistics:

Name       Memory usage
Jason 2           528 B
Jason             648 B - 1.23x memory usage +120 B
```

Will check Encode as well for a similar approach.