### PR TITLE
Removes unused Dialyzer ignored warnings

### DIFF
--- a/dialyzer.ignore
+++ b/dialyzer.ignore
@@ -1,5 +1,0 @@
-Unknown function 'Elixir.Jason.Encoder.Function':'__impl__'/1
-Unknown function 'Elixir.Jason.Encoder.PID':'__impl__'/1
-Unknown function 'Elixir.Jason.Encoder.Port':'__impl__'/1
-Unknown function 'Elixir.Jason.Encoder.Reference':'__impl__'/1
-Unknown function 'Elixir.Jason.Encoder.Tuple':'__impl__'/1

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,6 @@ defmodule Jason.Mixfile do
 
   defp dialyzer() do
     [
-      ignore_warnings: "dialyzer.ignore",
       plt_add_apps: [:decimal, :jason_native]
     ]
   end


### PR DESCRIPTION
From OTP 26, the `unknown function` warnings for `Jason.Encoder.(.*).__impl__` have stopped being raised by Dialyzer. It makes the `dialyzer.ignore` unnecessary-  especially because CI only runs Dialyzer with Elixir 1.15 and OTP 26.

This pull request simply removes the `dialyzer.ignore` file.