### PR TITLE
Fix non-deterministic test on OTP27

### DIFF
--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -227,11 +227,13 @@ defmodule Jason.EncoderTest do
   end
 
   test "pretty: true" do
-    assert to_json(%{a: 3.14159, b: 1}, pretty: true) == ~s|{\n  "a": 3.14159,\n  "b": 1\n}|
+    object = Jason.OrderedObject.new(a: 3.14159, b: 1)
+    assert to_json(object, pretty: true) == ~s|{\n  "a": 3.14159,\n  "b": 1\n}|
   end
 
   test "pretty: false" do
-    assert to_json(%{a: 3.14159, b: 1}, pretty: false) == ~s|{"a":3.14159,"b":1}|
+    object = Jason.OrderedObject.new(a: 3.14159, b: 1)
+    assert to_json(object, pretty: false) == ~s|{"a":3.14159,"b":1}|
   end
 
   defp to_json(value) do


### PR DESCRIPTION
Maps key ordering not being guaranteed anymore, the following tests are now frequently failing:

<img width="760" alt="Screenshot 2024-05-26 at 12 54 57" src="https://github.com/michalmuskala/jason/assets/11598866/360e74de-7c5a-4d89-a5a6-038f1bce020e">
